### PR TITLE
use classnames utility function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@navikt/ds-css": "~2.1.7",
         "@navikt/ds-react": "~2.1.7",
+        "classnames": "^2.3.2",
         "react": "~18.2.0",
         "react-dom": "~18.2.0"
       },
@@ -3761,6 +3762,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@navikt/ds-css": "~2.1.7",
     "@navikt/ds-react": "~2.1.7",
+    "classnames": "^2.3.2",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
   },

--- a/src/App/App.module.scss
+++ b/src/App/App.module.scss
@@ -10,12 +10,10 @@
   &:hover {
     filter: drop-shadow(0 0 2em var(--a-surface-action-hover));
   }
+}
 
-  &_react {
-    &:hover {
-      filter: drop-shadow(0 0 2em var(--a-surface-action-hover));
-    }
-  }
+.logo.react:hover {
+  filter: drop-shadow(0 0 2em var(--a-surface-action-hover));
 }
 
 .card {

--- a/src/App/App.module.scss.d.ts
+++ b/src/App/App.module.scss.d.ts
@@ -1,7 +1,7 @@
 import globalClassNames from '../style.d'
 declare const classNames: typeof globalClassNames & {
   readonly logo: 'logo'
-  readonly logo_react: 'logo_react'
+  readonly react: 'react'
   readonly card: 'card'
   readonly button: 'button'
 }

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react'
 
 import { Button, Heading } from '@navikt/ds-react'
+import cx from 'classnames'
 
 import reactLogo from '../assets/react.svg'
 import viteLogo from '../assets/vite.svg'
-import frameStyles from '../Frame/Frame.module.scss'
+import { Frame } from '../Frame/Frame'
 
 import { onButtonClick } from './App-utils'
 
@@ -35,9 +36,7 @@ export function App() {
   }, [])
 
   return (
-    <main
-      className={`${frameStyles.frame} ${frameStyles.frame_isFlex} ${frameStyles.frame_hasPadding}`}
-    >
+    <Frame tag="main" flex padded>
       <div>
         <a href="https://vitejs.dev" target="_blank">
           <img src={viteLogo} className={styles.logo} alt="Vite logo" />
@@ -45,7 +44,7 @@ export function App() {
         <a href="https://reactjs.org" target="_blank">
           <img
             src={reactLogo}
-            className={`${styles.logo} ${styles.logo_react}`}
+            className={cx(styles.logo, styles.react)}
             alt="React logo"
           />
         </a>
@@ -63,6 +62,6 @@ export function App() {
         </Button>
         <p>{'Du bør muligens spare bittelitt mer altså...'}</p>
       </div>
-    </main>
+    </Frame>
   )
 }

--- a/src/App/__tests__/__snapshots__/App.test.tsx.snap
+++ b/src/App/__tests__/__snapshots__/App.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Gitt at appen importeres, > Når Appen starter og at requesten er velly
 exports[`Gitt at appen importeres, > Når Appen starter og at requesten feiler, Så logges feilmeldingen og appen vises uten liveness status 1`] = `
 <DocumentFragment>
   <main
-    class="_frame_f5d647 _frame_isFlex_f5d647 _frame_hasPadding_f5d647"
+    class="_frame_f5d647 _padded_f5d647 _flex_f5d647"
   >
     <div>
       <a
@@ -24,7 +24,7 @@ exports[`Gitt at appen importeres, > Når Appen starter og at requesten feiler, 
       >
         <img
           alt="React logo"
-          class="_logo_728e4a _logo_react_728e4a"
+          class="_logo_728e4a _react_728e4a"
           src="/pensjon/kalkulator/src/assets/react.svg"
         />
       </a>

--- a/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/ErrorBoundary/ErrorBoundary.tsx
@@ -2,7 +2,7 @@ import React, { Component, ErrorInfo, ReactNode } from 'react'
 
 import { Alert, Heading } from '@navikt/ds-react'
 
-import frameStyles from '../Frame/Frame.module.scss'
+import { Frame } from '../Frame/Frame'
 
 interface Props {
   children: ReactNode
@@ -28,14 +28,14 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <div className={`${frameStyles.frame} ${frameStyles.frame_hasPadding}`}>
+        <Frame padded>
           <Alert variant="error">
             <Heading spacing size="small" level="1">
               Beklager, det har oppstått en feil
             </Heading>
             Lorem ipsum dolor sit amet
           </Alert>
-        </div>
+        </Frame>
       )
     }
 

--- a/src/ErrorBoundary/__tests__/__snapshots__/ErrorBoundary.test.tsx.snap
+++ b/src/ErrorBoundary/__tests__/__snapshots__/ErrorBoundary.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Gitt at ErrorBoundary wrapper en komponent, > Når den nested komponent kaster feil, Så vises det riktig feilmelding fra ErrorBoundary 1`] = `
 <DocumentFragment>
   <div
-    class="_frame_f5d647 _frame_hasPadding_f5d647"
+    class="_frame_f5d647 _padded_f5d647"
   >
     <div
       class="navds-alert navds-alert--error navds-alert--medium"

--- a/src/Frame/Frame.module.scss
+++ b/src/Frame/Frame.module.scss
@@ -8,15 +8,15 @@
   @media (min-width: $breakpoint-xl) {
     max-width: $content-area-desktop;
   }
+}
 
-  &_isFlex {
-    display: flex;
-    flex-flow: column;
-    place-items: center;
-    text-align: center;
-  }
+.frame.flex {
+  display: flex;
+  flex-flow: column;
+  place-items: center;
+  text-align: center;
+}
 
-  &_hasPadding {
-    padding: var(--a-spacing-8);
-  }
+.frame.padded {
+  padding: var(--a-spacing-8);
 }

--- a/src/Frame/Frame.module.scss.d.ts
+++ b/src/Frame/Frame.module.scss.d.ts
@@ -1,7 +1,7 @@
 import globalClassNames from '../style.d'
 declare const classNames: typeof globalClassNames & {
   readonly frame: 'frame'
-  readonly frame_isFlex: 'frame_isFlex'
-  readonly frame_hasPadding: 'frame_hasPadding'
+  readonly flex: 'flex'
+  readonly padded: 'padded'
 }
 export = classNames

--- a/src/Frame/Frame.tsx
+++ b/src/Frame/Frame.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+import cx from 'classnames'
+
+import styles from './Frame.module.scss'
+
+type FrameProps = React.HTMLAttributes<HTMLElement> & {
+  tag?: 'div' | 'main'
+  padded?: boolean
+  flex?: boolean
+}
+
+export function Frame({
+  tag = 'div',
+  padded,
+  flex,
+  children,
+  className,
+  ...elementProps
+}: FrameProps) {
+  return React.createElement(
+    tag,
+    {
+      className: cx(
+        styles.frame,
+        padded && styles.padded,
+        flex && styles.flex,
+        className
+      ),
+      ...elementProps,
+    },
+    children
+  )
+}


### PR DESCRIPTION
- Added a reusable Frame-component that encapsulates the Frame-styles
- Added package "classnames" to be able to cleanly toggle classnames conditionally without having to use template strings

### Forslag/brannfakkel 🔥:
Vi går vekk fra navngivingskonvensjonen i BEM. Syns ikke BEM gir mye verdi når vi uansett bruker CSS-moduler siden vi da har css som er scopet lokalt til komponenten som bruker det. BEM i dette tilfellet resulterer i at vi i tillegg får lange klassenavn som gjør at vi shipper unødig mye data.

Følgende:

<img width="705" alt="Screenshot 2023-03-07 at 12 05 51" src="https://user-images.githubusercontent.com/4243438/223408113-e9dc1e2a-49a5-49f2-a65c-384777a00fd3.png">

Blir:

<img width="512" alt="Screenshot 2023-03-07 at 12 08 16" src="https://user-images.githubusercontent.com/4243438/223408109-d115195b-57c8-44ae-8aa2-1bf55e97d14a.png">

### Forslag:
Vi importerer kun 1 stilark pr. komponent. Om man trenger å benytte seg av flere stilark i en komponent kan man heller lage en egen komponent som bruker det aktuelle stilarket. Eksempel:

Følgende:

<img width="841" alt="Screenshot 2023-03-07 at 12 32 10" src="https://user-images.githubusercontent.com/4243438/223410335-f56a7d4c-5722-4af1-bbc1-dc1d7c7f6497.png">

Blir: 

<img width="287" alt="Screenshot 2023-03-07 at 12 31 24" src="https://user-images.githubusercontent.com/4243438/223410338-698a8102-c8e9-48e5-adf9-aae0c2558d72.png">
