### PR TITLE
retter opp bug ved nullstilling av storen på samtykke steg

### DIFF
--- a/src/pages/Step2/Step2.tsx
+++ b/src/pages/Step2/Step2.tsx
@@ -26,6 +26,9 @@ export function Step2() {
     dispatch(userInputActions.setSamtykke(samtykke))
     if (!samtykke) {
       dispatch(apiSlice.util.resetApiState())
+      dispatch(apiSlice.endpoints.getSpraakvelgerFeatureToggle.initiate())
+      dispatch(apiSlice.endpoints.getPerson.initiate())
+      dispatch(apiSlice.endpoints.getInntekt.initiate())
     }
     navigate(paths.offentligTp)
   }


### PR DESCRIPTION
Når brukeren velger Nei på samtykke (Steg 2), sørger for at
- responser fra tidligere kall nullstilles 
- feature toggle, person og inntekt fetches på nytt 