### PR TITLE
fjerner animasjon og fjerner fetching av pensjonsavtaler i listener

### DIFF
--- a/src/components/Simulering/__tests__/__snapshots__/Simulering-utils-highcharts.test.ts.snap
+++ b/src/components/Simulering/__tests__/__snapshots__/Simulering-utils-highcharts.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Simulering-highcarts-utils > onPointClick og onPointUnclick > getChartOptions > returnerer riktig default options 1`] = `
 {
   "chart": {
+    "animation": false,
     "events": {
       "render": [Function],
     },

--- a/src/components/Simulering/utils-highcharts.ts
+++ b/src/components/Simulering/utils-highcharts.ts
@@ -190,6 +190,7 @@ export const getChartOptions = (
   return {
     chart: {
       type: 'column',
+      animation: false,
       spacingTop: 0,
       spacingBottom: 0,
       spacingLeft: 0,

--- a/src/state/listeners/__tests__/uttaksalderListener.test.ts
+++ b/src/state/listeners/__tests__/uttaksalderListener.test.ts
@@ -46,7 +46,7 @@ describe('uttaksalderListener', () => {
   })
 
   describe('Gitt at formatertUttaksalder oppdateres,', () => {
-    it('oppdaterer currentSimulation og kaller ikke /pensjonsavtaler når brukeren ikke har samtykket', async () => {
+    it('oppdaterer currentSimulation', async () => {
       store.dispatch(
         userInputActions.setFormatertUttaksalder('66 år og 5 måneder')
       )
@@ -58,26 +58,6 @@ describe('uttaksalderListener', () => {
       const currentSimulationUpdated = selectCurrentSimulation(store.getState())
       expect(currentSimulationUpdated.startAar).toBe(67)
       expect(currentSimulationUpdated.startMaaned).toBe(0)
-
-      const queries = store.getState().api.queries
-      expect(queries).toEqual({})
-    })
-
-    it('oppdaterer currentSimulation og kaller /pensjonsavtaler med riktig requestBody, når brukeren har samtykket og inntekt er hentet', async () => {
-      await store.dispatch(apiSlice.endpoints.getPerson.initiate())
-      await store.dispatch(apiSlice.endpoints.getInntekt.initiate())
-      store.dispatch(userInputActions.setSamtykke(true))
-      store.dispatch(
-        userInputActions.setFormatertUttaksalder('62 år og 2 måneder')
-      )
-      const currentSimulation = selectCurrentSimulation(store.getState())
-      expect(currentSimulation.startAar).toBe(62)
-      expect(currentSimulation.startMaaned).toBe(2)
-
-      const queries = store.getState().api.queries
-      expect(queries).toHaveProperty(
-        'pensjonsavtaler({"aarligInntektFoerUttak":521338,"antallInntektsaarEtterUttak":0,"harAfp":false,"sivilstand":"UGIFT","uttaksperioder":[{"aarligInntekt":0,"grad":100,"startAlder":{"aar":62,"maaneder":2}}]})'
-      )
     })
   })
 })

--- a/src/state/listeners/uttaksalderListener.ts
+++ b/src/state/listeners/uttaksalderListener.ts
@@ -25,7 +25,7 @@ import { userInputActions } from '@/state/userInput/userInputReducer'
  */
 async function onSetFormatertUttaksalder(
   { payload }: ReturnType<typeof userInputActions.setFormatertUttaksalder>,
-  { dispatch, getState }: AppListenerEffectAPI
+  { dispatch /* , getState*/ }: AppListenerEffectAPI
 ) {
   const uttaksalder = unformatUttaksalder(payload)
 
@@ -35,24 +35,6 @@ async function onSetFormatertUttaksalder(
       startMaaned: uttaksalder.maaneder,
     })
   )
-
-  const inntekt = selectInntekt(getState())
-  const samtykke = selectSamtykke(getState())
-  const afp = selectAfp(getState())
-  const sivilstand = selectSivilstand(getState())
-
-  if (samtykke && inntekt !== undefined) {
-    dispatch(
-      apiSlice.endpoints.pensjonsavtaler.initiate(
-        generatePensjonsavtalerRequestBody(
-          inntekt.beloep,
-          afp,
-          uttaksalder,
-          sivilstand
-        )
-      )
-    )
-  }
 }
 
 // Vil kalle onSetFormatertUttaksalder hver gang setFormatertUttaksalder kjører


### PR DESCRIPTION
- fjerner animasjon for søyler i graphen (beholder kun start-animasjonen)
- fjerner fetching av pensjonsavtaler i listener (unødvendig i og med at pensjonsavtaler fetches hver gang valgt uttaksalder endres i Simulering)