### PR TITLE
Bugfix/pek 60

### DIFF
--- a/src/components/common/Card/Card.module.scss
+++ b/src/components/common/Card/Card.module.scss
@@ -8,6 +8,10 @@
     composes: innerframe__largePadding from '../../../scss/modules/frame.module.scss';
   }
 
+  &__noPadding {
+    composes: innerframe__noPadding from '../../../scss/modules/frame.module.scss';
+  }
+
   &__marginBotton {
     /* important er nødvendig for å overskrive innerframe compose */
     margin-bottom: var(--a-spacing-10) !important;

--- a/src/components/common/Card/Card.module.scss.d.ts
+++ b/src/components/common/Card/Card.module.scss.d.ts
@@ -2,6 +2,7 @@ import globalClassNames from '../../../style.d'
 declare const classNames: typeof globalClassNames & {
   readonly section: 'section'
   readonly section__largePadding: 'section__largePadding'
+  readonly section__noPadding: 'section__noPadding'
   readonly section__marginBotton: 'section__marginBotton'
 }
 export = classNames

--- a/src/components/common/Card/Card.tsx
+++ b/src/components/common/Card/Card.tsx
@@ -12,14 +12,15 @@ export interface CardComponent extends React.FC<CardProps> {
 
 type CardProps = React.HTMLAttributes<HTMLElement> & {
   hasLargePadding?: boolean
-  hasMargin?: boolean
   hasNoPadding?: boolean
+  hasMargin?: boolean
 }
 
 export const Card = (({
   className,
   children,
   hasLargePadding,
+  hasNoPadding,
   hasMargin,
   ...elementProps
 }) => {
@@ -29,6 +30,7 @@ export const Card = (({
         styles.section,
         {
           [styles.section__largePadding]: hasLargePadding,
+          [styles.section__noPadding]: hasNoPadding,
           [styles.section__marginBotton]: hasMargin,
         },
         className

--- a/src/pages/Personopplysninger/Personopplysninger.tsx
+++ b/src/pages/Personopplysninger/Personopplysninger.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
 
+import { Box } from '@navikt/ds-react'
 import { BodyLong, Heading } from '@navikt/ds-react'
 
 import { Card } from '@/components/common/Card'
@@ -16,7 +17,8 @@ export function Personopplysninger() {
   }, [])
 
   return (
-    <Card hasLargePadding hasMargin>
+    <Card hasNoPadding hasMargin>
+      <Box padding="3"></Box>
       <Heading level="2" size="medium" spacing>
         <FormattedMessage id="personopplysninger.header" />
       </Heading>

--- a/src/router/__tests__/routes.test.tsx
+++ b/src/router/__tests__/routes.test.tsx
@@ -8,7 +8,7 @@ import { HOST_BASEURL } from '@/paths'
 import { apiSlice } from '@/state/api/apiSlice'
 import { store } from '@/state/store'
 import { userInputInitialState } from '@/state/userInput/userInputReducer'
-import { render, screen, swallowErrors, waitFor } from '@/test-utils'
+import { act, render, screen, swallowErrors, waitFor } from '@/test-utils'
 
 const initialGetState = store.getState
 
@@ -28,7 +28,6 @@ const fakeApiCalls = {
     },
   },
 }
-// TODO restrukturere tester per "ingen krav på login", "krav på login"
 // TODO mangler tester for henvisning etter start, utenlandsopphold, utenlandsoppholdFeil og stepFeil
 describe('routes', () => {
   afterEach(() => {
@@ -39,324 +38,677 @@ describe('routes', () => {
     store.getState = initialGetState
   })
 
-  describe(`${BASE_PATH}${paths.login}`, () => {
-    it('viser landingssiden med lenke til pålogging (stegvisning start)', async () => {
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.login}`],
+  describe(`Gitt at siden er åpen uten pålogging`, () => {
+    describe(`${BASE_PATH}${paths.root}`, () => {
+      it('redirigerer til /login', async () => {
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.root}`],
+        })
+        render(<RouterProvider router={router} />, { hasRouter: false })
+        expect(
+          await screen.findByText('landingsside.for.deg.foedt.foer.1963')
+        ).toBeVisible()
       })
-      render(<RouterProvider router={router} />, { hasRouter: false })
-      expect(router.state.location.pathname).toBe(`${BASE_PATH}/login`)
     })
-  })
 
-  describe(`${BASE_PATH}${paths.root}`, () => {
-    it('redirigerer til /login', async () => {
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.root}`],
+    describe(`${BASE_PATH}${paths.login}`, () => {
+      it('viser landingssiden med lenke til pålogging (stegvisning start)', async () => {
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.login}`],
+        })
+        render(<RouterProvider router={router} />, { hasRouter: false })
+        expect(router.state.location.pathname).toBe(`${BASE_PATH}/login`)
       })
-      render(<RouterProvider router={router} />, { hasRouter: false })
-      expect(
-        await screen.findByText('landingsside.for.deg.foedt.foer.1963')
-      ).toBeVisible()
     })
-  })
 
-  describe(`${BASE_PATH}${paths.start}`, () => {
-    it('sjekker påloggingstatus og redirigerer til ID-porten hvis brukeren ikke er pålogget', async () => {
-      const open = vi.fn()
-      vi.stubGlobal('open', open)
-      mockErrorResponse('/oauth2/session', {
-        baseUrl: `${HOST_BASEURL}`,
-      })
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.start}`],
-      })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
-      })
-      await waitFor(() => {
-        expect(open).toHaveBeenCalledWith(
-          'http://localhost:8088/pensjon/kalkulator/oauth2/login?redirect=%2F',
-          '_self'
+    describe(`${BASE_PATH}${paths.personopplysninger}`, () => {
+      it('viser personopplysninger siden', async () => {
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.personopplysninger}`],
+        })
+        render(<RouterProvider router={router} />, { hasRouter: false })
+        expect(router.state.location.pathname).toBe(
+          `${BASE_PATH}/personopplysninger`
         )
-      })
-    })
-    it('viser Steg 1', async () => {
-      mockResponse('/oauth2/session', {
-        baseUrl: `${HOST_BASEURL}`,
-      })
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.start}`],
-      })
-      render(<RouterProvider router={router} />, { hasRouter: false })
-
-      expect(
-        await screen.findByText('stegvisning.start.title Aprikos!')
-      ).toBeVisible()
-    })
-  })
-
-  describe(`${BASE_PATH}${paths.samtykke}`, () => {
-    it('redirigerer til Step 1 når brukeren prøver å aksessere steget med direkte url', async () => {
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.samtykke}`],
-      })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
-      })
-      expect(
-        await screen.findByText('stegvisning.start.button')
-      ).toBeInTheDocument()
-    })
-
-    it('viser Steg 2 når brukeren kommer til steget gjennom stegvisningen', async () => {
-      store.getState = vi.fn().mockImplementation(() => ({
-        api: {
-          ...fakeApiCalls,
-        },
-        userInput: { ...userInputInitialState },
-      }))
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.samtykke}`],
-      })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
-      })
-      expect(
-        await screen.findByText('stegvisning.samtykke.title')
-      ).toBeInTheDocument()
-    })
-  })
-
-  describe(`${BASE_PATH}${paths.offentligTp}`, () => {
-    it('redirigerer til Step 1 når brukeren prøver å aksessere steget med direkte url', async () => {
-      store.getState = vi.fn().mockImplementation(() => ({
-        api: {},
-        userInput: { ...userInputInitialState },
-      }))
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.offentligTp}`],
-      })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
-      })
-      expect(
-        await screen.findByText('stegvisning.start.button')
-      ).toBeInTheDocument()
-    })
-
-    it('viser Steg 3 når brukeren kommer til steget gjennom stegvisningen og har tpo-medlemskap', async () => {
-      store.getState = vi.fn().mockImplementation(() => ({
-        api: {
-          ...fakeApiCalls,
-        },
-        userInput: { ...userInputInitialState, samtykke: true },
-      }))
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.offentligTp}`],
-      })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
-      })
-      expect(
-        await screen.findByText('stegvisning.offentligtp.title')
-      ).toBeVisible()
-    })
-
-    it('redirigerer til Step 4 når brukeren har svart nei på spørsmålet om samtykke', async () => {
-      store.getState = vi.fn().mockImplementation(() => ({
-        api: {
-          ...fakeApiCalls,
-        },
-        userInput: { ...userInputInitialState, samtykke: false },
-      }))
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.offentligTp}`],
-      })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
-      })
-      expect(await screen.findByText('stegvisning.afp.title')).toBeVisible()
-    })
-
-    it('redirigerer til Step 4 når brukeren har samtykket og ikke har noe offentlig tjenestepensjonsforhold', async () => {
-      mockResponse('/tpo-medlemskap', {
-        status: 200,
-        json: { harTjenestepensjonsforhold: false },
-      })
-      store.getState = vi.fn().mockImplementation(() => ({
-        api: {
-          ...fakeApiCalls,
-        },
-        userInput: { ...userInputInitialState, samtykke: true },
-      }))
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.offentligTp}`],
-      })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
-      })
-      await waitFor(async () => {
-        expect(await screen.findByText('stegvisning.afp.title')).toBeVisible()
-      })
-    })
-  })
-
-  describe(`${BASE_PATH}${paths.afp}`, () => {
-    it('redirigerer til Step 1 når brukeren prøver å aksessere steget med direkte url', async () => {
-      store.getState = vi.fn().mockImplementation(() => ({
-        api: {},
-        userInput: { ...userInputInitialState },
-      }))
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.afp}`],
-      })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
-      })
-      expect(
-        await screen.findByText('stegvisning.start.button')
-      ).toBeInTheDocument()
-    })
-
-    it('viser Steg 4 når brukeren kommer til steget gjennom stegvisningen og har tpo medlemskap', async () => {
-      store.getState = vi.fn().mockImplementation(() => ({
-        api: {
-          ...fakeApiCalls,
-        },
-        userInput: { ...userInputInitialState, samtykke: true },
-      }))
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.afp}`],
-      })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
-      })
-      expect(
-        await screen.findByText('stegvisning.afp.title')
-      ).toBeInTheDocument()
-    })
-  })
-
-  describe(`${BASE_PATH}${paths.sivilstand}`, () => {
-    it('redirigerer til Step 1 når brukeren prøver å aksessere steget med direkte url', async () => {
-      store.getState = vi.fn().mockImplementation(() => ({
-        api: {},
-        userInput: { ...userInputInitialState },
-      }))
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.sivilstand}`],
-      })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
-      })
-      expect(
-        await screen.findByText('stegvisning.start.button')
-      ).toBeInTheDocument()
-    })
-
-    it('viser Steg 5 når brukeren kommer til steget gjennom stegvisningen', async () => {
-      store.getState = vi.fn().mockImplementation(() => ({
-        api: {
-          ...fakeApiCalls,
-        },
-        userInput: { ...userInputInitialState, samtykke: true },
-      }))
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.sivilstand}`],
-      })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
-      })
-      expect(
-        await screen.findByText('stegvisning.sivilstand.title')
-      ).toBeInTheDocument()
-    })
-  })
-
-  describe(`${BASE_PATH}${paths.beregning}`, () => {
-    it('redirigerer til Step 1 når brukeren prøver å aksessere steget med direkte url', async () => {
-      store.getState = vi.fn().mockImplementation(() => ({
-        api: {},
-        userInput: { ...userInputInitialState },
-      }))
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.beregning}`],
-      })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
-      })
-      expect(
-        await screen.findByText('stegvisning.start.button')
-      ).toBeInTheDocument()
-    })
-
-    it('viser beregningen når brukeren kommer til steget gjennom stegvisningen', async () => {
-      store.getState = vi.fn().mockImplementation(() => ({
-        api: {
-          ...fakeApiCalls,
-        },
-        userInput: { ...userInputInitialState, samtykke: true },
-      }))
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.beregning}`],
-      })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
-      })
-
-      await waitFor(async () => {
         expect(
-          screen.queryByTestId('uttaksalder-loader')
-        ).not.toBeInTheDocument()
-        expect(
-          await screen.findByText('Når vil du ta ut alderspensjon?')
+          await screen.findByText('personopplysninger.header')
         ).toBeInTheDocument()
       })
     })
   })
 
-  describe(`${BASE_PATH}${paths.forbehold}`, () => {
-    it('viser forbehold siden', async () => {
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.forbehold}`],
+  describe(`Gitt at siden er en del av stegvisningen`, () => {
+    describe(`${BASE_PATH}${paths.start}`, () => {
+      it('sjekker påloggingstatus og redirigerer til ID-porten hvis brukeren ikke er pålogget', async () => {
+        const open = vi.fn()
+        vi.stubGlobal('open', open)
+        mockErrorResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.start}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        await waitFor(() => {
+          expect(open).toHaveBeenCalledWith(
+            'http://localhost:8088/pensjon/kalkulator/oauth2/login?redirect=%2F',
+            '_self'
+          )
+        })
       })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
-      })
-      expect(await screen.findByText('forbehold.title')).toBeInTheDocument()
-    })
-  })
+      it('viser Steg 1', async () => {
+        mockResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.start}`],
+        })
+        render(<RouterProvider router={router} />, { hasRouter: false })
 
-  describe(`${BASE_PATH}${paths.personopplysninger}`, () => {
-    it('viser personopplysninger siden', async () => {
-      const router = createMemoryRouter(routes, {
-        basename: BASE_PATH,
-        initialEntries: [`${BASE_PATH}${paths.personopplysninger}`],
+        expect(
+          await screen.findByText('stegvisning.start.title Aprikos!')
+        ).toBeVisible()
       })
-      render(<RouterProvider router={router} />, {
-        hasRouter: false,
+    })
+
+    describe(`${BASE_PATH}${paths.henvisningUfoeretrygdGjenlevendepensjon}`, () => {
+      it('sjekker påloggingstatus og redirigerer til ID-porten hvis brukeren ikke er pålogget', async () => {
+        const open = vi.fn()
+        vi.stubGlobal('open', open)
+        mockErrorResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [
+            `${BASE_PATH}${paths.henvisningUfoeretrygdGjenlevendepensjon}`,
+          ],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        await waitFor(() => {
+          expect(open).toHaveBeenCalledWith(
+            'http://localhost:8088/pensjon/kalkulator/oauth2/login?redirect=%2F',
+            '_self'
+          )
+        })
       })
-      expect(
-        await screen.findByText('personopplysninger.header')
-      ).toBeInTheDocument()
+      it('viser henvisning uføretrygd/gjenlevendepensjon', async () => {
+        mockResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [
+            `${BASE_PATH}${paths.henvisningUfoeretrygdGjenlevendepensjon}`,
+          ],
+        })
+        render(<RouterProvider router={router} />, { hasRouter: false })
+
+        expect(
+          await screen.findByTestId('henvisning-ufoere-gjenlevende')
+        ).toBeVisible()
+      })
+    })
+
+    describe(`${BASE_PATH}${paths.henvisning1963}`, () => {
+      it('sjekker påloggingstatus og redirigerer til ID-porten hvis brukeren ikke er pålogget', async () => {
+        const open = vi.fn()
+        vi.stubGlobal('open', open)
+        mockErrorResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.henvisning1963}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        await waitFor(() => {
+          expect(open).toHaveBeenCalledWith(
+            'http://localhost:8088/pensjon/kalkulator/oauth2/login?redirect=%2F',
+            '_self'
+          )
+        })
+      })
+      it('viser henvisning 1963', async () => {
+        mockResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.henvisning1963}`],
+        })
+        render(<RouterProvider router={router} />, { hasRouter: false })
+
+        expect(await screen.findByTestId('henvisning-1963')).toBeVisible()
+      })
+    })
+
+    describe(`${BASE_PATH}${paths.forbehold}`, () => {
+      it('sjekker påloggingstatus og redirigerer til ID-porten hvis brukeren ikke er pålogget', async () => {
+        const open = vi.fn()
+        vi.stubGlobal('open', open)
+        mockErrorResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.forbehold}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        await waitFor(() => {
+          expect(open).toHaveBeenCalledWith(
+            'http://localhost:8088/pensjon/kalkulator/oauth2/login?redirect=%2F',
+            '_self'
+          )
+        })
+      })
+      it('viser forbehold siden', async () => {
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.forbehold}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(await screen.findByText('forbehold.title')).toBeInTheDocument()
+      })
+    })
+
+    describe(`${BASE_PATH}${paths.utenlandsopphold}`, () => {
+      it('sjekker påloggingstatus og redirigerer til ID-porten hvis brukeren ikke er pålogget', async () => {
+        const open = vi.fn()
+        vi.stubGlobal('open', open)
+        mockErrorResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.utenlandsopphold}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        await waitFor(() => {
+          expect(open).toHaveBeenCalledWith(
+            'http://localhost:8088/pensjon/kalkulator/oauth2/login?redirect=%2F',
+            '_self'
+          )
+        })
+      })
+      it('redirigerer til Step 1 når brukeren prøver å aksessere steget med direkte url', async () => {
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {},
+          userInput: { ...userInputInitialState },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.utenlandsopphold}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(
+          await screen.findByText('stegvisning.start.button')
+        ).toBeInTheDocument()
+      })
+      it('viser utenlandsopphold når brukeren kommer til steget gjennom stegvisningen og har tpo medlemskap', async () => {
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {
+            ...fakeApiCalls,
+          },
+          userInput: { ...userInputInitialState, samtykke: true },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.utenlandsopphold}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(
+          await screen.findByText('stegvisning.utenlandsopphold.title')
+        ).toBeInTheDocument()
+      })
+    })
+
+    describe(`${BASE_PATH}${paths.utenlandsoppholdFeil}`, () => {
+      it('sjekker påloggingstatus og redirigerer til ID-porten hvis brukeren ikke er pålogget', async () => {
+        const open = vi.fn()
+        vi.stubGlobal('open', open)
+        mockErrorResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.utenlandsoppholdFeil}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        await waitFor(() => {
+          expect(open).toHaveBeenCalledWith(
+            'http://localhost:8088/pensjon/kalkulator/oauth2/login?redirect=%2F',
+            '_self'
+          )
+        })
+      })
+      it('viser utenlandsopphold feil', async () => {
+        mockResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.utenlandsoppholdFeil}`],
+        })
+        render(<RouterProvider router={router} />, { hasRouter: false })
+
+        expect(
+          await screen.findByText('stegvisning.utenlandsopphold.error.title')
+        ).toBeVisible()
+      })
+    })
+
+    describe(`${BASE_PATH}${paths.samtykke}`, () => {
+      it('sjekker påloggingstatus og redirigerer til ID-porten hvis brukeren ikke er pålogget', async () => {
+        const open = vi.fn()
+        vi.stubGlobal('open', open)
+        mockErrorResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.samtykke}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        await waitFor(() => {
+          expect(open).toHaveBeenCalledWith(
+            'http://localhost:8088/pensjon/kalkulator/oauth2/login?redirect=%2F',
+            '_self'
+          )
+        })
+      })
+      it('redirigerer til Step 1 når brukeren prøver å aksessere steget med direkte url', async () => {
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.samtykke}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(
+          await screen.findByText('stegvisning.start.button')
+        ).toBeInTheDocument()
+      })
+
+      it('viser Steg 2 når brukeren kommer til steget gjennom stegvisningen', async () => {
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {
+            ...fakeApiCalls,
+          },
+          userInput: { ...userInputInitialState },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.samtykke}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(
+          await screen.findByText('stegvisning.samtykke.title')
+        ).toBeInTheDocument()
+      })
+    })
+
+    describe(`${BASE_PATH}${paths.offentligTp}`, () => {
+      it('sjekker påloggingstatus og redirigerer til ID-porten hvis brukeren ikke er pålogget', async () => {
+        const open = vi.fn()
+        vi.stubGlobal('open', open)
+        mockErrorResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.offentligTp}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        await waitFor(() => {
+          expect(open).toHaveBeenCalledWith(
+            'http://localhost:8088/pensjon/kalkulator/oauth2/login?redirect=%2F',
+            '_self'
+          )
+        })
+      })
+      it('redirigerer til Step 1 når brukeren prøver å aksessere steget med direkte url', async () => {
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {},
+          userInput: { ...userInputInitialState },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.offentligTp}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(
+          await screen.findByText('stegvisning.start.button')
+        ).toBeInTheDocument()
+      })
+
+      it('viser Steg 3 når brukeren kommer til steget gjennom stegvisningen og har tpo-medlemskap', async () => {
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {
+            ...fakeApiCalls,
+          },
+          userInput: { ...userInputInitialState, samtykke: true },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.offentligTp}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(
+          await screen.findByText('stegvisning.offentligtp.title')
+        ).toBeVisible()
+      })
+
+      it('redirigerer til Step 4 når brukeren har svart nei på spørsmålet om samtykke', async () => {
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {
+            ...fakeApiCalls,
+          },
+          userInput: { ...userInputInitialState, samtykke: false },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.offentligTp}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(await screen.findByText('stegvisning.afp.title')).toBeVisible()
+      })
+
+      it('redirigerer til Step 4 når brukeren har samtykket og ikke har noe offentlig tjenestepensjonsforhold', async () => {
+        mockResponse('/tpo-medlemskap', {
+          status: 200,
+          json: { harTjenestepensjonsforhold: false },
+        })
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {
+            ...fakeApiCalls,
+          },
+          userInput: { ...userInputInitialState, samtykke: true },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.offentligTp}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        await waitFor(async () => {
+          expect(await screen.findByText('stegvisning.afp.title')).toBeVisible()
+        })
+      })
+    })
+
+    describe(`${BASE_PATH}${paths.afp}`, () => {
+      it('sjekker påloggingstatus og redirigerer til ID-porten hvis brukeren ikke er pålogget', async () => {
+        const open = vi.fn()
+        vi.stubGlobal('open', open)
+        mockErrorResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.afp}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        await waitFor(() => {
+          expect(open).toHaveBeenCalledWith(
+            'http://localhost:8088/pensjon/kalkulator/oauth2/login?redirect=%2F',
+            '_self'
+          )
+        })
+      })
+      it('redirigerer til Step 1 når brukeren prøver å aksessere steget med direkte url', async () => {
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {},
+          userInput: { ...userInputInitialState },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.afp}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(
+          await screen.findByText('stegvisning.start.button')
+        ).toBeInTheDocument()
+      })
+
+      it('viser Steg 4 når brukeren kommer til steget gjennom stegvisningen og har tpo medlemskap', async () => {
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {
+            ...fakeApiCalls,
+          },
+          userInput: { ...userInputInitialState, samtykke: true },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.afp}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(
+          await screen.findByText('stegvisning.afp.title')
+        ).toBeInTheDocument()
+      })
+    })
+
+    describe(`${BASE_PATH}${paths.sivilstand}`, () => {
+      it('sjekker påloggingstatus og redirigerer til ID-porten hvis brukeren ikke er pålogget', async () => {
+        const open = vi.fn()
+        vi.stubGlobal('open', open)
+        mockErrorResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.sivilstand}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        await waitFor(() => {
+          expect(open).toHaveBeenCalledWith(
+            'http://localhost:8088/pensjon/kalkulator/oauth2/login?redirect=%2F',
+            '_self'
+          )
+        })
+      })
+      it('redirigerer til Step 1 når brukeren prøver å aksessere steget med direkte url', async () => {
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {},
+          userInput: { ...userInputInitialState },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.sivilstand}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(
+          await screen.findByText('stegvisning.start.button')
+        ).toBeInTheDocument()
+      })
+
+      it('viser Steg 5 når brukeren kommer til steget gjennom stegvisningen', async () => {
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {
+            ...fakeApiCalls,
+          },
+          userInput: { ...userInputInitialState, samtykke: true },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.sivilstand}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(
+          await screen.findByText('stegvisning.sivilstand.title')
+        ).toBeInTheDocument()
+      })
+    })
+
+    describe(`${BASE_PATH}${paths.uventetFeil}`, () => {
+      it('sjekker påloggingstatus og redirigerer til ID-porten hvis brukeren ikke er pålogget', async () => {
+        const open = vi.fn()
+        vi.stubGlobal('open', open)
+        mockErrorResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.uventetFeil}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        await waitFor(() => {
+          expect(open).toHaveBeenCalledWith(
+            'http://localhost:8088/pensjon/kalkulator/oauth2/login?redirect=%2F',
+            '_self'
+          )
+        })
+      })
+      it('redirigerer til Step 1 når brukeren prøver å aksessere steget med direkte url', async () => {
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {},
+          userInput: { ...userInputInitialState },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.uventetFeil}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(
+          await screen.findByText('stegvisning.start.button')
+        ).toBeInTheDocument()
+      })
+
+      it('viser uventet feil når brukeren kommer til steget gjennom stegvisningen', async () => {
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {
+            ...fakeApiCalls,
+          },
+          userInput: { ...userInputInitialState, samtykke: true },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.uventetFeil}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(
+          await screen.findByTestId('error-step-unexpected')
+        ).toBeInTheDocument()
+      })
+    })
+
+    describe(`${BASE_PATH}${paths.beregning}`, () => {
+      it('sjekker påloggingstatus og redirigerer til ID-porten hvis brukeren ikke er pålogget', async () => {
+        const open = vi.fn()
+        vi.stubGlobal('open', open)
+        mockErrorResponse('/oauth2/session', {
+          baseUrl: `${HOST_BASEURL}`,
+        })
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.beregning}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        await waitFor(() => {
+          expect(open).toHaveBeenCalledWith(
+            'http://localhost:8088/pensjon/kalkulator/oauth2/login?redirect=%2F',
+            '_self'
+          )
+        })
+      })
+      it('redirigerer til Step 1 når brukeren prøver å aksessere steget med direkte url', async () => {
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {},
+          userInput: { ...userInputInitialState },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.beregning}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+        expect(
+          await screen.findByText('stegvisning.start.button')
+        ).toBeInTheDocument()
+      })
+
+      it('viser beregningen når brukeren kommer til steget gjennom stegvisningen', async () => {
+        store.getState = vi.fn().mockImplementation(() => ({
+          api: {
+            ...fakeApiCalls,
+          },
+          userInput: { ...userInputInitialState, samtykke: true },
+        }))
+        const router = createMemoryRouter(routes, {
+          basename: BASE_PATH,
+          initialEntries: [`${BASE_PATH}${paths.beregning}`],
+        })
+        render(<RouterProvider router={router} />, {
+          hasRouter: false,
+        })
+
+        await waitFor(async () => {
+          expect(
+            screen.queryByTestId('uttaksalder-loader')
+          ).not.toBeInTheDocument()
+          expect(
+            await screen.findByText('Når vil du ta ut alderspensjon?')
+          ).toBeInTheDocument()
+        })
+      })
     })
   })
 

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -109,6 +109,10 @@ export const routes: RouteObject[] = [
         element: <Henvisning1963 />,
       },
       {
+        path: paths.forbehold,
+        element: <Forbehold />,
+      },
+      {
         loader: directAccessGuard,
         path: paths.utenlandsopphold,
         element: <Step1 />,
@@ -141,10 +145,6 @@ export const routes: RouteObject[] = [
         loader: directAccessGuard,
         path: paths.uventetFeil,
         element: <StepFeil />,
-      },
-      {
-        path: paths.forbehold,
-        element: <Forbehold />,
       },
     ],
   },

--- a/src/scss/modules/frame.module.scss
+++ b/src/scss/modules/frame.module.scss
@@ -32,4 +32,8 @@
       padding: var(--a-spacing-8) var(--a-spacing-10);
     }
   }
+
+  &__noPadding {
+    padding: 0;
+  }
 }

--- a/src/scss/modules/frame.module.scss.d.ts
+++ b/src/scss/modules/frame.module.scss.d.ts
@@ -4,5 +4,6 @@ declare const classNames: typeof globalClassNames & {
   readonly frame__hasPadding: 'frame__hasPadding'
   readonly innerframe: 'innerframe'
   readonly innerframe__largePadding: 'innerframe__largePadding'
+  readonly innerframe__noPadding: 'innerframe__noPadding'
 }
 export = classNames


### PR DESCRIPTION
- refaktor routes.test.tsx
- fikser styling på personopplysninger.tsx slik at den kan bruke samme mal som /login