### PR TITLE
PEK-233 Deploy version for veiledere (dev only)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,17 +46,17 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
       - name: Fetch openapi backend types
-        run: npx openapi-typescript ${{ github.event.inputs.prod  == 'true' && 'https://www.nav.no/pensjon/kalkulator/v3/api-docs/api' || 'https://www.ekstern.dev.nav.no/pensjon/kalkulator/v3/api-docs/api' }} -o ./src/types/schema.d.ts
+        run: npx openapi-typescript ${{ github.event.inputs.prod == 'true' && 'https://www.nav.no/pensjon/kalkulator/v3/api-docs/api' || 'https://www.ekstern.dev.nav.no/pensjon/kalkulator/v3/api-docs/api' }} -o ./src/types/schema.d.ts
 
       - name: Fetch openapi backend types
         run: npm run format:types
 
       - name: Build staging application
-        if: github.event.inputs.prod  != 'true'
+        if: github.event.inputs.prod != 'true'
         run: npm run build
 
       - name: Build production application
-        if: github.event.inputs.prod  == 'true'
+        if: github.event.inputs.prod == 'true'
         run: npm run build:production
 
       - name: Save build folder
@@ -217,6 +217,13 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .nais/deploy-dev.yml
+
+      - name: Deploy veiledning to dev-gcp
+        uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/deploy-veiledning-dev.yml
 
   deploy-prod:
     name: Deploy to prod-gcp

--- a/.nais/deploy-veiledning-dev.yml
+++ b/.nais/deploy-veiledning-dev.yml
@@ -1,0 +1,62 @@
+apiVersion: nais.io/v1alpha1
+kind: Application
+metadata:
+  name: pensjonskalkulator-veiledning-frontend
+  namespace: pensjonskalkulator
+  labels:
+    team: pensjonskalkulator
+  annotations:
+    nais.io/run-as-user: "101" # nginx
+spec:
+  image: "{{ image }}"
+  ingresses:
+    - https://pensjonskalkulator-veiledning-frontend.intern.dev.nav.no
+  port: 8080
+  replicas:
+    min: 2
+    max: 2
+  liveness:
+    path: /internal/health/liveness
+    initialDelay: 20
+    periodSeconds: 20
+    failureThreshold: 5
+    timeout: 1
+  readiness:
+    path: /internal/health/readiness
+    initialDelay: 20
+    periodSeconds: 20
+    failureThreshold: 5
+    timeout: 1
+  frontend:
+    generatedConfig:
+      mountPath: /usr/share/nginx/html/src/nais.js
+  azure:
+    application:
+      enabled: true
+      claims:
+        groups:
+          - id: "a3f91493-1ab8-4b64-a544-0a77cbba9240" # 0000-GA-Pensjon_VEILEDER
+          - id: "dbe4ad45-320b-4e9a-aaa1-73cca4ee124d" # 0000-GA-Egne_ansatte
+          - id: "ea930b6b-9397-44d9-b9e6-f4cf527a632a" # 0000-GA-Fortrolig_Adresse
+          - id: "5ef775f2-61f8-4283-bf3d-8d03f428aa14" # 0000-GA-Strengt_Fortrolig_Adresse
+        extra:
+          - NAVident
+    sidecar:
+      enabled: true
+      autoLogin: true
+      autoLoginIgnorePaths:
+        - /internal/ping
+        - /pensjon/kalkulator
+        - /pensjon/kalkulator/login
+        - /pensjon/kalkulator/personopplysninger
+        - /pensjon/kalkulator/assets/*
+        - /pensjon/kalkulator/api/status
+        - /pensjon/kalkulator/api/feature/*
+        - /pensjon/kalkulator/src/*
+  accessPolicy:
+    outbound:
+      rules:
+        - application: pensjonskalkulator-backend
+  env:
+    - name: "PENSJONSKALKULATOR_BACKEND"
+      value: "http://pensjonskalkulator-backend"


### PR DESCRIPTION
Konfig for tilgang som NAV-ansatt veileder (foreløpig bare i _dev_).

Hovedforskjellen mellom "veileder"-versjon og normal versjon er denne NAIS-konfigen:
```
  azure:
    application:
      enabled: true
      claims:
        groups:
          - id: "a3f91493-1ab8-4b64-a544-0a77cbba9240" # 0000-GA-Pensjon_VEILEDER
          - id: "dbe4ad45-320b-4e9a-aaa1-73cca4ee124d" # 0000-GA-Egne_ansatte
          - id: "ea930b6b-9397-44d9-b9e6-f4cf527a632a" # 0000-GA-Fortrolig_Adresse
          - id: "5ef775f2-61f8-4283-bf3d-8d03f428aa14" # 0000-GA-Strengt_Fortrolig_Adresse
        extra:
          - NAVident
    sidecar:
      enabled: true
```
Her er [Azure AD sidecar](https://doc.nais.io/security/auth/azure-ad/sidecar/) skrudd på, hvilket gjør at uinnloggede brukere vil omdirigeres til Entra ID (Azure AD) for innlogging som NAV-ansatt.
Entra ID vil utstede et token (JWT) som vil inneholde et `groups` claim. Dette claimet vil inneholde et subsett av de angitte 4 gruppene, nemlig de gruppene som brukeren er medlem av. Dette vil backend bruke for tilgangskontroll.
Tokenet vil også inneholde NAV-identen, som vil brukes av backend for sporingslogging (hvem som har gjort noe på vegne av en annen).

Forklaring på gruppene:

- _0000-GA-Pensjon_VEILEDER_: Basistilgang for veiledere. Vil uten tilleggstilganger ikke ha tilgang til egne ansatte (skjermede personer) eller personer med adressebeskyttelse ("kode 6", "kode 7", "paragraf 19").
- _0000-GA-Egne_ansatte_: Tilleggstilgang. Gir tilgang til egne ansatte (skjermede personer).
- _0000-GA-Fortrolig_Adresse_: Tilleggstilgang. Gir tilgang til personer med fortrolig adresse ("kode 7").
- _0000-GA-Strengt_Fortrolig_Adresse_: Tilleggstilgang. Gir tilgang til personer med strengt fortrolig adresse ("kode 6", "paragraf 19").

For å kunne skille de to app-variantene brukes en annen ingress for veileder-versjonen:
```
  ingresses:
    - https://pensjonskalkulator-veiledning-frontend.intern.dev.nav.no
```