### PR TITLE
Bugfix tooltip plassering ved scroll

### DIFF
--- a/src/components/Simulering/Simulering.module.scss
+++ b/src/components/Simulering/Simulering.module.scss
@@ -100,6 +100,7 @@
   background-color: var(--a-white);
   min-height: 115px;
   z-index: 3;
+  position: relative;
 
   @media (min-width: $a-breakpoint-lg) {
     min-height: 0;
@@ -132,7 +133,7 @@
     width: 100%;
     table-layout: fixed;
     border-collapse: separate;
-    z-index: 1;
+    z-index: 4;
 
     @media (min-width: $a-breakpoint-lg) {
       width: 22rem;
@@ -242,12 +243,61 @@
     }
   }
 
-  .highcharts-scrollable-mask {
-    filter: drop-shadow(-5px 0 3px rgb(255 255 255 / 25%));
+  .highcharts-scrolling-parent {
+    // This creates a new stacking context
+    isolation: isolate;
+
+    // THis removes the stacking context from that node
+    .highcharts-container {
+      z-index: auto !important;
+    }
+
+    /* y-axis */
+    .highcharts-axis-labels.highcharts-yaxis-labels {
+      z-index: 2;
+      width: 30px;
+      height: 100%;
+      text-shadow:
+        1px 1px 2px #fff,
+        0 0 1em #fff,
+        0 0 0.2em #fff;
+
+      @media (min-width: $a-breakpoint-lg) {
+        width: 70px;
+      }
+
+      &::after {
+        content: '';
+        display: block;
+        position: absolute;
+        bottom: 0.25rem;
+        height: 80%;
+        width: 100%;
+        z-index: -1;
+        background: linear-gradient(
+          33deg,
+          rgb(255 255 255 / 75%) 40%,
+          rgb(255 255 255 / 0%) 80%
+        );
+
+        @media (min-width: $a-breakpoint-lg) {
+          bottom: 4rem;
+        }
+      }
+    }
+
+    .highcharts-scrollable-mask {
+      fill: white;
+      filter: drop-shadow(-5px 0 3px rgb(255 255 255 / 50%));
+    }
   }
 
   .highcharts-root path:hover {
     cursor: pointer;
+  }
+
+  .highcharts-background {
+    fill: transparent;
   }
 }
 

--- a/src/components/Simulering/Simulering.module.scss.d.ts
+++ b/src/components/Simulering/Simulering.module.scss.d.ts
@@ -15,6 +15,9 @@ declare const classNames: typeof globalClassNames & {
   readonly tooltip: 'tooltip'
   readonly tooltipTable: 'tooltipTable'
   readonly tooltipLine: 'tooltipLine'
+  readonly 'highcharts-scrolling-parent': 'highcharts-scrolling-parent'
+  readonly 'highcharts-axis-labels': 'highcharts-axis-labels'
+  readonly 'highcharts-yaxis-labels': 'highcharts-yaxis-labels'
   readonly tooltipTableHeaderCell: 'tooltipTableHeaderCell'
   readonly tooltipTableCell: 'tooltipTableCell'
   readonly tooltipTableHeaderCell__left: 'tooltipTableHeaderCell__left'
@@ -24,7 +27,9 @@ declare const classNames: typeof globalClassNames & {
   readonly 'highcharts-loading': 'highcharts-loading'
   readonly 'highcharts-loading-inner': 'highcharts-loading-inner'
   readonly 'highcharts-tooltip-container': 'highcharts-tooltip-container'
+  readonly 'highcharts-container': 'highcharts-container'
   readonly 'highcharts-scrollable-mask': 'highcharts-scrollable-mask'
   readonly 'highcharts-root': 'highcharts-root'
+  readonly 'highcharts-background': 'highcharts-background'
 }
 export = classNames

--- a/src/components/Simulering/__tests__/__snapshots__/Simulering-utils-highcharts.test.ts.snap
+++ b/src/components/Simulering/__tests__/__snapshots__/Simulering-utils-highcharts.test.ts.snap
@@ -134,6 +134,7 @@ exports[`Simulering-utils-highcharts > onPointClick og onPointUnclick > getChart
     "followTouchMove": false,
     "formatter": [Function],
     "hideDelay": 9000000000,
+    "outside": false,
     "padding": 0,
     "positioner": [Function],
     "shadow": false,

--- a/src/components/Simulering/utils-highcharts.ts
+++ b/src/components/Simulering/utils-highcharts.ts
@@ -212,21 +212,21 @@ export const getChartOptions = (
       },
       events: {
         render(this) {
-          const highchartsScrollingElement = document.querySelector(
-            highchartsScrollingSelector
-          )
-          if (highchartsScrollingElement) {
-            const el =
-              highchartsScrollingElement as HighchartsScrollingHTMLDivElement
-            const scrollPosition = el.scrollLeft
-            if (el.handleButtonVisibility !== undefined) {
-              handleChartScroll({ currentTarget: el } as unknown as Event, {
-                chart: this,
-                scrollPosition,
-              })
-            } else {
-              // Denne setTimeout er nødvendig fordi highcharts tegner scroll container litt etter render callback og har ikke noe eget flag for den
-              const timeout = setTimeout(() => {
+          // Denne setTimeout er nødvendig fordi highcharts tegner scroll container litt etter render callback og har ikke noe eget flag for den
+          const timeout = setTimeout(() => {
+            const highchartsScrollingElement = document.querySelector(
+              highchartsScrollingSelector
+            )
+            if (highchartsScrollingElement) {
+              const el =
+                highchartsScrollingElement as HighchartsScrollingHTMLDivElement
+              const scrollPosition = el.scrollLeft
+              if (el.handleButtonVisibility !== undefined) {
+                handleChartScroll({ currentTarget: el } as unknown as Event, {
+                  chart: this,
+                  scrollPosition,
+                })
+              } else {
                 const elementScrollWidth = el.scrollWidth
                 const elementWidth = el.offsetWidth
                 showRightButton(elementScrollWidth > elementWidth)
@@ -241,16 +241,17 @@ export const getChartOptions = (
                   showRightButton,
                   showLeftButton,
                 }
-                // Dette er meningsløst for koden som kjører i browser'en, men ser ut til å spare vitest for hanging processes
-                clearTimeout(timeout)
-              }, 50)
+              }
+            } else {
+              showRightButton(false)
+              showLeftButton(false)
             }
-          } else {
-            showRightButton(false)
-            showLeftButton(false)
-          }
-          const el1 = document.querySelector('[data-highcharts-chart]')
-          el1?.setAttribute('data-testid', 'highcharts-done-drawing')
+            const el1 = document.querySelector('[data-highcharts-chart]')
+            el1?.setAttribute('data-testid', 'highcharts-done-drawing')
+            // Dette er meningsløst for koden som kjører i browser'en, men ser ut til å spare vitest for hanging processes
+
+            clearTimeout(timeout)
+          }, 50)
         },
       },
     },
@@ -326,6 +327,7 @@ export const getChartOptions = (
       enabled: false,
     },
     tooltip: {
+      outside: false,
       className: styles.tooltip,
       animation: false,
       followTouchMove: false,


### PR DESCRIPTION
- legger til eksplisitt konfigurasjonsparameter `outside` til `false` i highcharts slik at tooltip alltid plasseres inne i scrolling-området
- ordner stacking context (z-index) på de ulike highcharts layers slik at tooltip alltid vises øverst, og svg-søylene nederst. 
- fjerner scrolling-mask på venstre og høyre side (fordi svg-element kan vi ikke kontrollere z-index på), og legger heller en hvit gradert bakgrunn fra y-axis slik.