### PR TITLE
Forenkler logikken for bakgrunnsfarge på beregningssiden

### DIFF
--- a/src/pages/Beregning/Beregning.module.scss
+++ b/src/pages/Beregning/Beregning.module.scss
@@ -2,7 +2,6 @@
 
 .beregning {
   width: 100%;
-  background-color: var(--a-gray-100);
 }
 
 .container {

--- a/src/pages/Beregning/BeregningAvansert.module.scss
+++ b/src/pages/Beregning/BeregningAvansert.module.scss
@@ -18,8 +18,7 @@
   left: 0;
   right: 0;
 
-  &__white {
-    background-color: var(--a-white);
-    transition: background-color 0.15s ease;
+  &__lightgray {
+    background-color: var(--a-gray-100);
   }
 }

--- a/src/pages/Beregning/BeregningAvansert.module.scss.d.ts
+++ b/src/pages/Beregning/BeregningAvansert.module.scss.d.ts
@@ -4,6 +4,6 @@ declare const classNames: typeof globalClassNames & {
   readonly container__hasMobilePadding: "container__hasMobilePadding";
   readonly container__hasTopMargin: "container__hasTopMargin";
   readonly background: "background";
-  readonly background__white: "background__white";
+  readonly background__lightgray: "background__lightgray";
 };
 export = classNames;

--- a/src/pages/Beregning/BeregningAvansert.tsx
+++ b/src/pages/Beregning/BeregningAvansert.tsx
@@ -121,60 +121,60 @@ export const BeregningAvansert: React.FC = () => {
         />
       )}
       {modus === 'resultat' && (
-        <div
-          className={`${styles.container} ${styles.container__hasMobilePadding}`}
-        >
-          <ResultatkortAvansertBeregning
-            onButtonClick={() => setModus('redigering')}
-          />
+        <div className={clsx(styles.background, styles.background__lightgray)}>
+          <div
+            className={`${styles.container} ${styles.container__hasMobilePadding}`}
+          >
+            <ResultatkortAvansertBeregning
+              onButtonClick={() => setModus('redigering')}
+            />
+          </div>{' '}
         </div>
       )}
 
-      <div className={clsx(styles.background, styles.background__white)}>
-        {modus === 'resultat' && (
-          <div
-            className={`${styles.container} ${styles.container__hasMobilePadding} ${styles.container__hasTopMargin}`}
-          >
-            {isError || (alderspensjon && !alderspensjon?.vilkaarErOppfylt) ? (
-              <>
-                <Heading level="2" size="small">
-                  <FormattedMessage id="beregning.title" />
-                </Heading>
-                <Alert onRetry={isError ? onRetry : undefined}>
-                  {startAlder && startAlder.aar < 67 && (
-                    <FormattedMessage
-                      id="beregning.lav_opptjening"
-                      values={{ startAar: startAlder.aar }}
-                    />
-                  )}
-                  {isError && <FormattedMessage id="beregning.error" />}
-                </Alert>
-              </>
-            ) : (
-              <>
-                <PensjonsavtalerAccordionContext.Provider
-                  value={{
-                    ref: grunnlagPensjonsavtalerRef,
-                    isOpen: isPensjonsavtalerAccordionItemOpen,
-                    toggleOpen: togglePensjonsavtalerAccordionItem,
-                  }}
-                >
-                  <Simulering
-                    isLoading={isFetching}
-                    aarligInntektFoerUttak={aarligInntektFoerUttak ?? 0}
-                    alderspensjon={alderspensjon}
-                    showAfp={afp === 'ja_privat'}
-                    showButtonsAndTable={
-                      !isError && alderspensjon?.vilkaarErOppfylt
-                    }
+      {modus === 'resultat' && (
+        <div
+          className={`${styles.container} ${styles.container__hasMobilePadding} ${styles.container__hasTopMargin}`}
+        >
+          {isError || (alderspensjon && !alderspensjon?.vilkaarErOppfylt) ? (
+            <>
+              <Heading level="2" size="small">
+                <FormattedMessage id="beregning.title" />
+              </Heading>
+              <Alert onRetry={isError ? onRetry : undefined}>
+                {startAlder && startAlder.aar < 67 && (
+                  <FormattedMessage
+                    id="beregning.lav_opptjening"
+                    values={{ startAar: startAlder.aar }}
                   />
-                  <Grunnlag />
-                </PensjonsavtalerAccordionContext.Provider>
-              </>
-            )}
-          </div>
-        )}
-      </div>
+                )}
+                {isError && <FormattedMessage id="beregning.error" />}
+              </Alert>
+            </>
+          ) : (
+            <>
+              <PensjonsavtalerAccordionContext.Provider
+                value={{
+                  ref: grunnlagPensjonsavtalerRef,
+                  isOpen: isPensjonsavtalerAccordionItemOpen,
+                  toggleOpen: togglePensjonsavtalerAccordionItem,
+                }}
+              >
+                <Simulering
+                  isLoading={isFetching}
+                  aarligInntektFoerUttak={aarligInntektFoerUttak ?? 0}
+                  alderspensjon={alderspensjon}
+                  showAfp={afp === 'ja_privat'}
+                  showButtonsAndTable={
+                    !isError && alderspensjon?.vilkaarErOppfylt
+                  }
+                />
+                <Grunnlag />
+              </PensjonsavtalerAccordionContext.Provider>
+            </>
+          )}
+        </div>
+      )}
     </>
   )
 }

--- a/src/pages/Beregning/BeregningEnkel.module.scss
+++ b/src/pages/Beregning/BeregningEnkel.module.scss
@@ -14,8 +14,7 @@
   left: 0;
   right: 0;
 
-  &__white {
-    background-color: var(--a-white);
-    transition: background-color 0.15s ease;
+  &__lightgray {
+    background-color: var(--a-gray-100);
   }
 }

--- a/src/pages/Beregning/BeregningEnkel.module.scss.d.ts
+++ b/src/pages/Beregning/BeregningEnkel.module.scss.d.ts
@@ -3,6 +3,6 @@ declare const classNames: typeof globalClassNames & {
   readonly container: "container";
   readonly container__hasMobilePadding: "container__hasMobilePadding";
   readonly background: "background";
-  readonly background__white: "background__white";
+  readonly background__lightgray: "background__lightgray";
 };
 export = classNames;

--- a/src/pages/Beregning/BeregningEnkel.tsx
+++ b/src/pages/Beregning/BeregningEnkel.tsx
@@ -113,63 +113,63 @@ export const BeregningEnkel: React.FC<Props> = ({ tidligstMuligUttak }) => {
 
   return (
     <>
-      <div className={styles.container}>
-        <TidligstMuligUttaksalder
-          tidligstMuligUttak={tidligstMuligUttak}
-          hasAfpOffentlig={afp === 'ja_offentlig'}
-          show1963Text={show1963Text}
-        />
-      </div>
-
-      <div className={clsx(styles.background, styles.background__white)}>
+      <div className={clsx(styles.background, styles.background__lightgray)}>
         <div className={styles.container}>
-          <VelgUttaksalder tidligstMuligUttak={tidligstMuligUttak} />
+          <TidligstMuligUttaksalder
+            tidligstMuligUttak={tidligstMuligUttak}
+            hasAfpOffentlig={afp === 'ja_offentlig'}
+            show1963Text={show1963Text}
+          />
         </div>
-
-        {startAlder !== null && (
-          <div
-            className={`${styles.container} ${styles.container__hasMobilePadding}`}
-          >
-            {isError || (alderspensjon && !alderspensjon?.vilkaarErOppfylt) ? (
-              <>
-                <Heading level="2" size="small">
-                  <FormattedMessage id="beregning.title" />
-                </Heading>
-                <Alert onRetry={isError ? onRetry : undefined}>
-                  {startAlder && startAlder.aar < 67 && (
-                    <FormattedMessage
-                      id="beregning.lav_opptjening"
-                      values={{ startAar: startAlder.aar }}
-                    />
-                  )}
-                  {isError && <FormattedMessage id="beregning.error" />}
-                </Alert>
-              </>
-            ) : (
-              <>
-                <PensjonsavtalerAccordionContext.Provider
-                  value={{
-                    ref: grunnlagPensjonsavtalerRef,
-                    isOpen: isPensjonsavtalerAccordionItemOpen,
-                    toggleOpen: togglePensjonsavtalerAccordionItem,
-                  }}
-                >
-                  <Simulering
-                    isLoading={isFetching}
-                    aarligInntektFoerUttak={aarligInntektFoerUttak ?? 0}
-                    alderspensjon={alderspensjon}
-                    showAfp={afp === 'ja_privat'}
-                    showButtonsAndTable={
-                      !isError && alderspensjon?.vilkaarErOppfylt
-                    }
-                  />
-                  <Grunnlag />
-                </PensjonsavtalerAccordionContext.Provider>
-              </>
-            )}
-          </div>
-        )}
       </div>
+
+      <div className={styles.container}>
+        <VelgUttaksalder tidligstMuligUttak={tidligstMuligUttak} />
+      </div>
+
+      {startAlder !== null && (
+        <div
+          className={`${styles.container} ${styles.container__hasMobilePadding}`}
+        >
+          {isError || (alderspensjon && !alderspensjon?.vilkaarErOppfylt) ? (
+            <>
+              <Heading level="2" size="small">
+                <FormattedMessage id="beregning.title" />
+              </Heading>
+              <Alert onRetry={isError ? onRetry : undefined}>
+                {startAlder && startAlder.aar < 67 && (
+                  <FormattedMessage
+                    id="beregning.lav_opptjening"
+                    values={{ startAar: startAlder.aar }}
+                  />
+                )}
+                {isError && <FormattedMessage id="beregning.error" />}
+              </Alert>
+            </>
+          ) : (
+            <>
+              <PensjonsavtalerAccordionContext.Provider
+                value={{
+                  ref: grunnlagPensjonsavtalerRef,
+                  isOpen: isPensjonsavtalerAccordionItemOpen,
+                  toggleOpen: togglePensjonsavtalerAccordionItem,
+                }}
+              >
+                <Simulering
+                  isLoading={isFetching}
+                  aarligInntektFoerUttak={aarligInntektFoerUttak ?? 0}
+                  alderspensjon={alderspensjon}
+                  showAfp={afp === 'ja_privat'}
+                  showButtonsAndTable={
+                    !isError && alderspensjon?.vilkaarErOppfylt
+                  }
+                />
+                <Grunnlag />
+              </PensjonsavtalerAccordionContext.Provider>
+            </>
+          )}
+        </div>
+      )}
     </>
   )
 }


### PR DESCRIPTION
- setter hvit bakgrunn som default på `Beregning` (istedenfor lysgrå tidligere)
- legger til felt for lysgrå bakgrunn øverst på siden
- fjerner alle de hvite feltene som er nå unødvendig