### PR TITLE
PEK-247 - kobler mot v2 av simuleringsendepunktet

### DIFF
--- a/src/components/EndreInntektVsaPensjon/EndreInntektVsaPensjon.tsx
+++ b/src/components/EndreInntektVsaPensjon/EndreInntektVsaPensjon.tsx
@@ -24,13 +24,11 @@ export const EndreInntektVsaPensjon: React.FC<Props> = ({
   const dispatch = useAppDispatch()
 
   const inntektVsaPensjonModalRef = React.useRef<HTMLDialogElement>(null)
-  const { aarligInntektVedSidenAvPensjon } = useAppSelector(
-    selectCurrentSimulation
-  )
+  const { aarligInntektVsaPensjon } = useAppSelector(selectCurrentSimulation)
 
   const [validationError, setValidationError] = React.useState<string>('')
   const [inntektVsaPensjon, setInntektVsaPensjon] = React.useState<string>(
-    aarligInntektVedSidenAvPensjon?.toString() ?? ''
+    aarligInntektVsaPensjon?.toString() ?? ''
   )
 
   const handleTextfieldChange = (
@@ -133,13 +131,13 @@ export const EndreInntektVsaPensjon: React.FC<Props> = ({
         </Modal.Footer>
       </Modal>
       <hr className={styles.separator} />
-      {aarligInntektVedSidenAvPensjon ? (
+      {aarligInntektVsaPensjon ? (
         <>
           <Label>
             <FormattedMessage id="inntekt.endre_inntekt_vsa_pensjon_modal.label" />
           </Label>
           <p>{`${formatWithoutDecimal(
-            aarligInntektVedSidenAvPensjon
+            aarligInntektVsaPensjon
           )} kr ${intl.formatMessage({
             id: 'beregning.avansert.resultatkort.fra',
           })} ${

--- a/src/components/EndreInntektVsaPensjon/__tests__/EndreInntektVsaPensjon.test.tsx
+++ b/src/components/EndreInntektVsaPensjon/__tests__/EndreInntektVsaPensjon.test.tsx
@@ -9,7 +9,7 @@ describe('EndreInntektVsaPensjon', async () => {
     const { store } = render(<EndreInntektVsaPensjon />)
 
     expect(
-      selectCurrentSimulation(store.getState()).aarligInntektVedSidenAvPensjon
+      selectCurrentSimulation(store.getState()).aarligInntektVsaPensjon
     ).toBe(undefined)
     expect(
       screen.getByText('inntekt.endre_inntekt_vsa_pensjon_modal.ingress_2')
@@ -29,7 +29,7 @@ describe('EndreInntektVsaPensjon', async () => {
       screen.getByText('inntekt.endre_inntekt_vsa_pensjon_modal.button')
     )
     expect(
-      selectCurrentSimulation(store.getState()).aarligInntektVedSidenAvPensjon
+      selectCurrentSimulation(store.getState()).aarligInntektVsaPensjon
     ).toBe(123000)
 
     expect(
@@ -68,7 +68,7 @@ describe('EndreInntektVsaPensjon', async () => {
             ...userInputInitialState,
             currentSimulation: {
               ...userInputInitialState.currentSimulation,
-              aarligInntektVedSidenAvPensjon: 123000,
+              aarligInntektVsaPensjon: 123000,
               startAlder: { aar: 67, maaneder: 3 },
               formatertUttaksalderReadOnly: '67 år og 3 md.',
             },
@@ -102,7 +102,7 @@ describe('EndreInntektVsaPensjon', async () => {
     )
 
     expect(
-      selectCurrentSimulation(store.getState()).aarligInntektVedSidenAvPensjon
+      selectCurrentSimulation(store.getState()).aarligInntektVsaPensjon
     ).toBe(99000)
     expect(
       screen.getByText(

--- a/src/components/Grunnlag/GrunnlagPensjonsavtaler/GrunnlagPensjonsavtaler.tsx
+++ b/src/components/Grunnlag/GrunnlagPensjonsavtaler/GrunnlagPensjonsavtaler.tsx
@@ -54,7 +54,7 @@ export const GrunnlagPensjonsavtaler = () => {
       const requestBody = generatePensjonsavtalerRequestBody(
         aarligInntektFoerUttak ?? 0,
         afp,
-        startAlder,
+        { uttaksalder: startAlder },
         sivilstand
       )
       setPensjonsavtalerRequestBody(requestBody)

--- a/src/components/Grunnlag/GrunnlagPensjonsavtaler/__tests__/GrunnlagPensjonsavtaler.test.tsx
+++ b/src/components/Grunnlag/GrunnlagPensjonsavtaler/__tests__/GrunnlagPensjonsavtaler.test.tsx
@@ -30,10 +30,10 @@ describe('GrunnlagPensjonsavtaler', () => {
   }
 
   const currentSimulation: Simulation = {
-    uttaksperioder: [],
     formatertUttaksalderReadOnly: '67 år string.og 1 alder.maaned',
     startAlder: { aar: 67, maaneder: 1 },
     aarligInntektFoerUttak: 0,
+    gradertUttaksperiode: null,
   }
   describe('Gitt at brukeren ikke har samtykket', () => {
     it('viser riktig header og melding med lenke tilbake til start, og skjuler ingress og tabell', async () => {

--- a/src/components/ResultatkortAvansertBeregning/ResultatkortAvansertBeregning.tsx
+++ b/src/components/ResultatkortAvansertBeregning/ResultatkortAvansertBeregning.tsx
@@ -24,7 +24,7 @@ export const ResultatkortAvansertBeregning: React.FC<Props> = ({
   const intl = useIntl()
   const aarligInntektFoerUttak = useAppSelector(selectAarligInntektFoerUttak)
 
-  const { startAlder, uttaksperioder, aarligInntektVedSidenAvPensjon } =
+  const { startAlder, aarligInntektVsaPensjon, gradertUttaksperiode } =
     useAppSelector(selectCurrentSimulation)
 
   return (
@@ -43,67 +43,63 @@ export const ResultatkortAvansertBeregning: React.FC<Props> = ({
               id: 'beregning.avansert.resultatkort.inntekt_2',
             })}
           </dd>
-          {uttaksperioder.map(
-            ({ startAlder: startAlderGradertPensjon, grad, aarligInntekt }) => {
-              if (startAlder && startAlderGradertPensjon)
-                return (
-                  <>
-                    <dt className={styles.cardLeftListTitle}>
-                      {intl.formatMessage({
-                        id: 'beregning.avansert.resultatkort.Fra',
-                      })}
-                      {formatUttaksalder(
-                        intl,
-                        {
-                          aar: startAlderGradertPensjon.aar,
-                          maaneder: startAlderGradertPensjon.maaneder,
-                        },
-                        { compact: true }
-                      )}
-                      {intl.formatMessage({
-                        id: 'beregning.avansert.resultatkort.til',
-                      })}
+          {startAlder && gradertUttaksperiode?.uttaksalder && (
+            <>
+              <dt className={styles.cardLeftListTitle}>
+                {intl.formatMessage({
+                  id: 'beregning.avansert.resultatkort.Fra',
+                })}
+                {formatUttaksalder(
+                  intl,
+                  {
+                    aar: gradertUttaksperiode.uttaksalder.aar,
+                    maaneder: gradertUttaksperiode.uttaksalder.maaneder,
+                  },
+                  { compact: true }
+                )}
+                {intl.formatMessage({
+                  id: 'beregning.avansert.resultatkort.til',
+                })}
 
-                      {formatUttaksalder(
-                        intl,
-                        {
-                          aar:
-                            startAlder.maaneder > 0
-                              ? startAlder.aar
-                              : startAlder.aar - 1,
-                          maaneder:
-                            startAlder.maaneder > 0
-                              ? startAlder.maaneder - 1
-                              : 11,
-                        },
-                        { compact: true }
-                      )}
-                    </dt>
-                    <dd className={styles.cardLeftListDescription}>
-                      {grad && (
-                        <>
-                          {intl.formatMessage({
-                            id: 'beregning.avansert.resultatkort.alderspensjon',
-                          })}
-                          {grad} %<br />
-                        </>
-                      )}
-                      {aarligInntekt && (
-                        <>
-                          {intl.formatMessage({
-                            id: 'beregning.avansert.resultatkort.inntekt_1',
-                          })}
-                          {formatWithoutDecimal(aarligInntekt)}
-                          {intl.formatMessage({
-                            id: 'beregning.avansert.resultatkort.inntekt_2',
-                          })}
-                        </>
-                      )}
-                    </dd>
+                {formatUttaksalder(
+                  intl,
+                  {
+                    aar:
+                      startAlder.maaneder > 0
+                        ? startAlder.aar
+                        : startAlder.aar - 1,
+                    maaneder:
+                      startAlder.maaneder > 0 ? startAlder.maaneder - 1 : 11,
+                  },
+                  { compact: true }
+                )}
+              </dt>
+              <dd className={styles.cardLeftListDescription}>
+                {gradertUttaksperiode.grad && (
+                  <>
+                    {intl.formatMessage({
+                      id: 'beregning.avansert.resultatkort.alderspensjon',
+                    })}
+                    {gradertUttaksperiode.grad} %<br />
                   </>
-                )
-            }
+                )}
+                {gradertUttaksperiode.aarligInntektVsaPensjon && (
+                  <>
+                    {intl.formatMessage({
+                      id: 'beregning.avansert.resultatkort.inntekt_1',
+                    })}
+                    {formatWithoutDecimal(
+                      gradertUttaksperiode.aarligInntektVsaPensjon
+                    )}
+                    {intl.formatMessage({
+                      id: 'beregning.avansert.resultatkort.inntekt_2',
+                    })}
+                  </>
+                )}
+              </dd>
+            </>
           )}
+
           <dt className={styles.cardLeftListTitle}>
             {intl.formatMessage({
               id: 'beregning.avansert.resultatkort.Fra',
@@ -129,13 +125,13 @@ export const ResultatkortAvansertBeregning: React.FC<Props> = ({
               id: 'beregning.avansert.resultatkort.alderspensjon',
             })}
             100 %
-            {aarligInntektVedSidenAvPensjon && (
+            {aarligInntektVsaPensjon && (
               <>
                 <br />
                 {intl.formatMessage({
                   id: 'beregning.avansert.resultatkort.inntekt_1',
                 })}
-                {formatWithoutDecimal(aarligInntektVedSidenAvPensjon)}
+                {formatWithoutDecimal(aarligInntektVsaPensjon)}
                 {intl.formatMessage({
                   id: 'beregning.avansert.resultatkort.inntekt_2',
                 })}

--- a/src/components/Simulering/Simulering.tsx
+++ b/src/components/Simulering/Simulering.tsx
@@ -77,7 +77,8 @@ export function Simulering(props: {
     isOpen: isPensjonsavtalerAccordionItemOpen,
     toggleOpen: togglePensjonsavtalerAccordionItem,
   } = React.useContext(PensjonsavtalerAccordionContext)
-  const { startAlder } = useAppSelector(selectCurrentSimulation)
+  const { startAlder, aarligInntektVsaPensjon, gradertUttaksperiode } =
+    useAppSelector(selectCurrentSimulation)
 
   const [pensjonsavtalerRequestBody, setPensjonsavtalerRequestBody] =
     React.useState<PensjonsavtalerRequestBody | undefined>(undefined)
@@ -117,14 +118,24 @@ export function Simulering(props: {
   // Hent pensjonsavtaler
   React.useEffect(() => {
     if (harSamtykket && startAlder) {
+      const optionalGradertUttakObj = gradertUttaksperiode
+        ? {
+            uttaksalder: gradertUttaksperiode.uttaksalder,
+            grad: gradertUttaksperiode.grad,
+            aarligInntektVsaPensjon:
+              gradertUttaksperiode.aarligInntektVsaPensjon,
+          }
+        : undefined
+
       const requestBody = generatePensjonsavtalerRequestBody(
         aarligInntektFoerUttak,
         afp,
         {
-          aar: startAlder.aar,
-          maaneder: startAlder.maaneder,
+          uttaksalder: startAlder,
+          aarligInntektVsaPensjon,
         },
-        sivilstand
+        sivilstand,
+        optionalGradertUttakObj
       )
       setPensjonsavtalerRequestBody(requestBody)
     }

--- a/src/components/Simulering/__tests__/Simulering.test.tsx
+++ b/src/components/Simulering/__tests__/Simulering.test.tsx
@@ -13,10 +13,10 @@ import { act, render, screen, waitFor, userEvent } from '@/test-utils'
 
 describe('Simulering', () => {
   const currentSimulation: Simulation = {
-    uttaksperioder: [],
     formatertUttaksalderReadOnly: '67 år string.og 0 alder.maaned',
     startAlder: { aar: 67, maaneder: 0 },
     aarligInntektFoerUttak: 0,
+    gradertUttaksperiode: null,
   }
 
   afterEach(() => {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -59,7 +59,18 @@ export const getHandlers = (baseUrl: string = API_PATH) => [
     const body = await request.json()
     const data = await import(
       `./data/alderspensjon/${
-        (body as AlderspensjonRequestBody).foersteUttaksalder.aar
+        (body as AlderspensjonEnkelRequestBody).foersteUttaksalder.aar
+      }.json`
+    )
+    return HttpResponse.json(data)
+  }),
+
+  http.post(`${baseUrl}/v2/alderspensjon/simulering`, async ({ request }) => {
+    await delay(TEST_DELAY)
+    const body = await request.json()
+    const data = await import(
+      `./data/alderspensjon/${
+        (body as AlderspensjonRequestBody).heltUttak.uttaksalder.aar
       }.json`
     )
     return HttpResponse.json(data)

--- a/src/pages/Beregning/BeregningAvansert.tsx
+++ b/src/pages/Beregning/BeregningAvansert.tsx
@@ -45,21 +45,31 @@ export const BeregningAvansert: React.FC = () => {
   )
   const { data: person } = useGetPersonQuery()
 
-  const { startAlder } = useAppSelector(selectCurrentSimulation)
+  const { startAlder, aarligInntektVsaPensjon, gradertUttaksperiode } =
+    useAppSelector(selectCurrentSimulation)
 
   const [alderspensjonRequestBody, setAlderspensjonRequestBody] =
     React.useState<AlderspensjonRequestBody | undefined>(undefined)
 
   React.useEffect(() => {
     if (startAlder) {
-      // TODO denne må kunne ta høyde for uttaksperioder og inntekt ved siden av alderspensjon
+      // TODO denne må kunne ta høyde for inntekt vsa gradert pensjon, og sluttdato for inntekt vsa helpensjon
       const requestBody = generateAlderspensjonRequestBody({
         afp,
         sivilstand: person?.sivilstand,
         harSamboer,
         foedselsdato: person?.foedselsdato,
         aarligInntektFoerUttak: aarligInntektFoerUttak ?? 0,
-        startAlder,
+        gradertUttak: gradertUttaksperiode
+          ? {
+              ...gradertUttaksperiode,
+            }
+          : undefined,
+        heltUttak: startAlder && {
+          uttaksalder: startAlder,
+          // inntektTomAlder?: Alder,
+          aarligInntektVsaPensjon,
+        },
       })
       setAlderspensjonRequestBody(requestBody)
     }

--- a/src/pages/Beregning/BeregningEnkel.tsx
+++ b/src/pages/Beregning/BeregningEnkel.tsx
@@ -14,9 +14,9 @@ import { VelgUttaksalder } from '@/components/VelgUttaksalder'
 import {
   useGetPersonQuery,
   apiSlice,
-  useAlderspensjonQuery,
+  useAlderspensjonEnkelQuery,
 } from '@/state/api/apiSlice'
-import { generateAlderspensjonRequestBody } from '@/state/api/utils'
+import { generateAlderspensjonEnkelRequestBody } from '@/state/api/utils'
 import { useAppDispatch, useAppSelector } from '@/state/hooks'
 import {
   selectAfp,
@@ -43,12 +43,12 @@ export const BeregningEnkel: React.FC<Props> = ({ tidligstMuligUttak }) => {
   const { isSuccess: isPersonSuccess, data: person } = useGetPersonQuery()
 
   const { startAlder } = useAppSelector(selectCurrentSimulation)
-  const [alderspensjonRequestBody, setAlderspensjonRequestBody] =
-    React.useState<AlderspensjonRequestBody | undefined>(undefined)
+  const [alderspensjonEnkelRequestBody, setAlderspensjonEnkelRequestBody] =
+    React.useState<AlderspensjonEnkelRequestBody | undefined>(undefined)
 
   React.useEffect(() => {
     if (startAlder) {
-      const requestBody = generateAlderspensjonRequestBody({
+      const requestBody = generateAlderspensjonEnkelRequestBody({
         afp,
         sivilstand: person?.sivilstand,
         harSamboer,
@@ -56,7 +56,7 @@ export const BeregningEnkel: React.FC<Props> = ({ tidligstMuligUttak }) => {
         aarligInntektFoerUttak: aarligInntektFoerUttak ?? 0,
         startAlder,
       })
-      setAlderspensjonRequestBody(requestBody)
+      setAlderspensjonEnkelRequestBody(requestBody)
     }
   }, [afp, person, aarligInntektFoerUttak, harSamboer, startAlder])
 
@@ -66,10 +66,10 @@ export const BeregningEnkel: React.FC<Props> = ({ tidligstMuligUttak }) => {
     isFetching,
     isError,
     error,
-  } = useAlderspensjonQuery(
-    alderspensjonRequestBody as AlderspensjonRequestBody,
+  } = useAlderspensjonEnkelQuery(
+    alderspensjonEnkelRequestBody as AlderspensjonEnkelRequestBody,
     {
-      skip: !alderspensjonRequestBody,
+      skip: !alderspensjonEnkelRequestBody,
     }
   )
 
@@ -104,9 +104,11 @@ export const BeregningEnkel: React.FC<Props> = ({ tidligstMuligUttak }) => {
 
   const onRetry = (): void => {
     dispatch(apiSlice.util.invalidateTags(['Alderspensjon']))
-    if (alderspensjonRequestBody) {
+    if (alderspensjonEnkelRequestBody) {
       dispatch(
-        apiSlice.endpoints.alderspensjon.initiate(alderspensjonRequestBody)
+        apiSlice.endpoints.alderspensjonEnkel.initiate(
+          alderspensjonEnkelRequestBody
+        )
       )
     }
   }

--- a/src/pages/Beregning/__tests__/Beregning.test.tsx
+++ b/src/pages/Beregning/__tests__/Beregning.test.tsx
@@ -72,11 +72,11 @@ describe('Beregning', () => {
             ...userInputInitialState,
             samtykke: true,
             currentSimulation: {
-              uttaksperioder: [],
               formatertUttaksalderReadOnly:
                 '70 alder.aar string.og 4 alder.maaned',
               startAlder: { aar: 70, maaneder: 4 },
               aarligInntektFoerUttak: 300000,
+              gradertUttaksperiode: null,
             },
           },
         },

--- a/src/pages/Beregning/__tests__/BeregningEnkel.test.tsx
+++ b/src/pages/Beregning/__tests__/BeregningEnkel.test.tsx
@@ -165,10 +165,10 @@ describe('BeregningEnkel', () => {
               samtykke: true,
               samboer: false,
               currentSimulation: {
-                uttaksperioder: [],
                 formatertUttaksalderReadOnly: '63 alder.aar',
                 startAlder: { aar: 63, maaneder: 0 },
                 aarligInntektFoerUttak: 0,
+                gradertUttaksperiode: null,
               },
             },
           },

--- a/src/pages/Beregning/__tests__/BeregningEnkel.test.tsx
+++ b/src/pages/Beregning/__tests__/BeregningEnkel.test.tsx
@@ -62,7 +62,7 @@ describe('BeregningEnkel', () => {
 
     it('viser feilmelding og skjuler Grunnlag og tabell og gir mulighet til å prøve på nytt, gitt at beregning av alderspensjon har feilet', async () => {
       const initiateMock = vi.spyOn(
-        apiSliceUtils.apiSlice.endpoints.alderspensjon,
+        apiSliceUtils.apiSlice.endpoints.alderspensjonEnkel,
         'initiate'
       )
       mockErrorResponse('/v1/alderspensjon/simulering', {

--- a/src/state/__tests__/__snapshots__/store.test.ts.snap
+++ b/src/state/__tests__/__snapshots__/store.test.ts.snap
@@ -24,8 +24,8 @@ exports[`store > returnerer store med riktig slices og default state 1`] = `
     "currentSimulation": {
       "aarligInntektFoerUttak": null,
       "formatertUttaksalderReadOnly": null,
+      "gradertUttaksperiode": null,
       "startAlder": null,
-      "uttaksperioder": [],
     },
     "samboer": null,
     "samtykke": null,

--- a/src/state/__tests__/store.test.ts
+++ b/src/state/__tests__/store.test.ts
@@ -17,10 +17,10 @@ describe('store', () => {
       afp: null,
       samboer: null,
       currentSimulation: {
-        uttaksperioder: [],
         formatertUttaksalderReadOnly: null,
         startAlder: null,
         aarligInntektFoerUttak: 500000,
+        gradertUttaksperiode: null,
       },
     }
 

--- a/src/state/api/__tests__/apiSlice-utils.test.ts
+++ b/src/state/api/__tests__/apiSlice-utils.test.ts
@@ -1,5 +1,6 @@
 import {
   generatePensjonsavtalerRequestBody,
+  generateAlderspensjonEnkelRequestBody,
   generateAlderspensjonRequestBody,
 } from '../utils'
 
@@ -8,8 +9,7 @@ describe('apiSlice - utils', () => {
     it('returnerer riktig requestBody når maaneder er 0 og sivilstand undefined', () => {
       expect(
         generatePensjonsavtalerRequestBody(500000, 'vet_ikke', {
-          aar: 67,
-          maaneder: 0,
+          uttaksalder: { aar: 67, maaneder: 0 },
         })
       ).toEqual({
         aarligInntektFoerUttak: 500000,
@@ -30,7 +30,10 @@ describe('apiSlice - utils', () => {
         generatePensjonsavtalerRequestBody(
           500000,
           'ja_privat',
-          { aar: 62, maaneder: 4 },
+          {
+            uttaksalder: { aar: 62, maaneder: 4 },
+            aarligInntektVsaPensjon: 99000,
+          },
           'GIFT'
         )
       ).toEqual({
@@ -39,13 +42,52 @@ describe('apiSlice - utils', () => {
         harAfp: true,
         sivilstand: 'GIFT',
         uttaksperioder: [
-          { startAlder: { aar: 62, maaneder: 4 }, grad: 100, aarligInntekt: 0 },
+          {
+            startAlder: { aar: 62, maaneder: 4 },
+            grad: 100,
+            aarligInntekt: 99000,
+          },
+        ],
+      })
+    })
+    it('returnerer riktig requestBodymed gradert periode', () => {
+      expect(
+        generatePensjonsavtalerRequestBody(
+          500000,
+          'ja_privat',
+          {
+            uttaksalder: { aar: 67, maaneder: 0 },
+            aarligInntektVsaPensjon: 99000,
+          },
+          'GIFT',
+          {
+            uttaksalder: { aar: 62, maaneder: 4 },
+            grad: 20,
+            aarligInntektVsaPensjon: 123000,
+          }
+        )
+      ).toEqual({
+        aarligInntektFoerUttak: 500000,
+        antallInntektsaarEtterUttak: 0,
+        harAfp: true,
+        sivilstand: 'GIFT',
+        uttaksperioder: [
+          {
+            startAlder: { aar: 62, maaneder: 4 },
+            grad: 20,
+            aarligInntekt: 123000,
+          },
+          {
+            startAlder: { aar: 67, maaneder: 0 },
+            grad: 100,
+            aarligInntekt: 99000,
+          },
         ],
       })
     })
   })
 
-  describe('generateAlderspensjonRequestBody', () => {
+  describe('generateAlderspensjonEnkelRequestBody', () => {
     const requestBody = {
       afp: 'ja_privat' as AfpRadio,
       sivilstand: 'GIFT' as Sivilstand,
@@ -57,7 +99,143 @@ describe('apiSlice - utils', () => {
     }
     it('returnerer undefined når foedselsdato, eller startAlder er null', () => {
       expect(
-        generateAlderspensjonRequestBody({ ...requestBody, foedselsdato: null })
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+          foedselsdato: null,
+        })
+      ).toEqual(undefined)
+      expect(
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+          foedselsdato: undefined,
+        })
+      ).toEqual(undefined)
+      expect(
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+          startAlder: null,
+        })
+      ).toEqual(undefined)
+    })
+    it('returnerer riktig simuleringstype', () => {
+      expect(
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+        })?.simuleringstype
+      ).toEqual('ALDERSPENSJON_MED_AFP_PRIVAT')
+      expect(
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+          afp: 'nei',
+        })?.simuleringstype
+      ).toEqual('ALDERSPENSJON')
+
+      expect(
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+          afp: null,
+        })?.simuleringstype
+      ).toEqual('ALDERSPENSJON')
+    })
+
+    it('returnerer riktig uttaksgrad', () => {
+      expect(
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+        })?.uttaksgrad
+      ).toEqual(100)
+    })
+    it('returnerer riktig sivilstand', () => {
+      expect(
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+        })?.sivilstand
+      ).toEqual('GIFT')
+      expect(
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+          sivilstand: null,
+        })?.sivilstand
+      ).toEqual('UGIFT')
+      expect(
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+          sivilstand: null,
+          harSamboer: true,
+        })?.sivilstand
+      ).toEqual('SAMBOER')
+      expect(
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+          sivilstand: 'UGIFT' as Sivilstand,
+        })?.sivilstand
+      ).toEqual('UGIFT')
+      expect(
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+          sivilstand: 'UGIFT' as Sivilstand,
+          harSamboer: true,
+        })?.sivilstand
+      ).toEqual('SAMBOER')
+    })
+
+    it('returnerer riktig forventetInntekt', () => {
+      expect(
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+        })?.forventetInntekt
+      ).toEqual(500000)
+    })
+
+    it('returnerer riktig uttaksalder', () => {
+      expect(
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+        })?.foersteUttaksalder
+      ).toEqual({
+        aar: 68,
+        maaneder: 3,
+      })
+      expect(
+        generateAlderspensjonEnkelRequestBody({
+          ...requestBody,
+          startAlder: { aar: 68, maaneder: 0 },
+        })?.foersteUttaksalder
+      ).toEqual({
+        aar: 68,
+        maaneder: 0,
+      })
+    })
+
+    it('formaterer streng dato korrekt', () => {
+      expect(
+        generateAlderspensjonEnkelRequestBody(requestBody)?.foedselsdato
+      ).toBe('1963-04-30')
+    })
+  })
+
+  describe('generateAlderspensjonRequestBody', () => {
+    const requestBody = {
+      afp: 'ja_privat' as AfpRadio,
+      sivilstand: 'GIFT' as Sivilstand,
+      harSamboer: false,
+      aarligInntektFoerUttak: 500000,
+      foedselsdato: '1963-04-30',
+      heltUttak: {
+        uttaksalder: { aar: 68, maaneder: 3 },
+        aarligInntektVsaPensjon: 99000,
+        inntektTomAlder: {
+          aar: 75,
+          maaneder: 0,
+        },
+      },
+    }
+    it('returnerer undefined når foedselsdato, eller heltUttak er null/undefined', () => {
+      expect(
+        generateAlderspensjonRequestBody({
+          ...requestBody,
+          foedselsdato: null,
+        })
       ).toEqual(undefined)
       expect(
         generateAlderspensjonRequestBody({
@@ -66,9 +244,13 @@ describe('apiSlice - utils', () => {
         })
       ).toEqual(undefined)
       expect(
-        generateAlderspensjonRequestBody({ ...requestBody, startAlder: null })
+        generateAlderspensjonRequestBody({
+          ...requestBody,
+          heltUttak: undefined,
+        })
       ).toEqual(undefined)
     })
+
     it('returnerer riktig simuleringstype', () => {
       expect(
         generateAlderspensjonRequestBody({
@@ -81,7 +263,6 @@ describe('apiSlice - utils', () => {
           afp: 'nei',
         })?.simuleringstype
       ).toEqual('ALDERSPENSJON')
-
       expect(
         generateAlderspensjonRequestBody({
           ...requestBody,
@@ -90,13 +271,6 @@ describe('apiSlice - utils', () => {
       ).toEqual('ALDERSPENSJON')
     })
 
-    it('returnerer riktig uttaksgrad', () => {
-      expect(
-        generateAlderspensjonRequestBody({
-          ...requestBody,
-        })?.uttaksgrad
-      ).toEqual(100)
-    })
     it('returnerer riktig sivilstand', () => {
       expect(
         generateAlderspensjonRequestBody({
@@ -131,32 +305,31 @@ describe('apiSlice - utils', () => {
       ).toEqual('SAMBOER')
     })
 
-    it('returnerer riktig forventetInntekt', () => {
-      expect(
-        generateAlderspensjonRequestBody({
-          ...requestBody,
-        })?.forventetInntekt
-      ).toEqual(500000)
+    it('returnerer riktig gradertUttak', () => {
+      const gradertUttak = generateAlderspensjonRequestBody({
+        ...requestBody,
+        gradertUttak: {
+          uttaksalder: { aar: 67, maaneder: 3 },
+          grad: 20,
+          aarligInntektVsaPensjon: 123000,
+        },
+      })?.gradertUttak
+      expect(gradertUttak?.grad).toEqual(20)
+      expect(gradertUttak?.aarligInntektVsaPensjon).toEqual(123000)
+      expect(gradertUttak?.uttaksalder.aar).toEqual(67)
+      expect(gradertUttak?.uttaksalder.maaneder).toEqual(3)
     })
 
-    it('returnerer riktig uttaksalder', () => {
-      expect(
-        generateAlderspensjonRequestBody({
-          ...requestBody,
-        })?.foersteUttaksalder
-      ).toEqual({
-        aar: 68,
-        maaneder: 3,
-      })
-      expect(
-        generateAlderspensjonRequestBody({
-          ...requestBody,
-          startAlder: { aar: 68, maaneder: 0 },
-        })?.foersteUttaksalder
-      ).toEqual({
-        aar: 68,
-        maaneder: 0,
-      })
+    it('returnerer riktig heltUttak', () => {
+      const heltUttak = generateAlderspensjonRequestBody({
+        ...requestBody,
+      })?.heltUttak
+
+      expect(heltUttak?.aarligInntektVsaPensjon).toEqual(99000)
+      expect(heltUttak?.uttaksalder.aar).toEqual(68)
+      expect(heltUttak?.uttaksalder.maaneder).toEqual(3)
+      expect(heltUttak?.inntektTomAlder.aar).toEqual(75)
+      expect(heltUttak?.inntektTomAlder.maaneder).toEqual(0)
     })
 
     it('formaterer streng dato korrekt', () => {

--- a/src/state/api/__tests__/apiSlice.test.ts
+++ b/src/state/api/__tests__/apiSlice.test.ts
@@ -330,52 +330,105 @@ describe('apiSlice', () => {
   })
 
   describe('alderspensjon', () => {
-    const body: AlderspensjonRequestBody = {
-      simuleringstype: 'ALDERSPENSJON_MED_AFP_PRIVAT',
-      uttaksgrad: 100,
-      foedselsdato: '1963-04-30',
-      foersteUttaksalder: { aar: 67, maaneder: 8 },
-      sivilstand: 'UGIFT',
-      epsHarInntektOver2G: true,
-    }
-    it('returnerer data ved vellykket query', async () => {
-      const storeRef = setupStore(undefined, true)
-      return storeRef
-        .dispatch<any>(apiSlice.endpoints.alderspensjon.initiate(body))
-        .then((result: FetchBaseQueryError) => {
-          expect(result.status).toBe('fulfilled')
-          expect(result.data).toMatchObject(alderspensjonResponse)
-        })
-    })
-
-    it('returnerer undefined ved feilende query', async () => {
-      const storeRef = setupStore(undefined, true)
-      mockErrorResponse('/v1/alderspensjon/simulering', {
-        method: 'post',
-      })
-      return storeRef
-        .dispatch<any>(apiSlice.endpoints.alderspensjon.initiate(body))
-        .then((result: FetchBaseQueryError) => {
-          expect(result.status).toBe('rejected')
-          expect(result.data).toBe(undefined)
-        })
-    })
-
-    it('kaster feil ved uventet format på responsen', async () => {
-      const storeRef = setupStore(undefined, true)
-      mockResponse('/v1/alderspensjon/simulering', {
-        status: 200,
-        json: [{ 'tullete svar': 'lorem' }],
-        method: 'post',
-      })
-      await swallowErrorsAsync(async () => {
-        await storeRef
-          .dispatch<any>(apiSlice.endpoints.alderspensjon.initiate(body))
+    describe('enkel', () => {
+      const body: AlderspensjonEnkelRequestBody = {
+        simuleringstype: 'ALDERSPENSJON_MED_AFP_PRIVAT',
+        uttaksgrad: 100,
+        foedselsdato: '1963-04-30',
+        foersteUttaksalder: { aar: 67, maaneder: 8 },
+        sivilstand: 'UGIFT',
+        epsHarInntektOver2G: true,
+      }
+      it('returnerer data ved vellykket query', async () => {
+        const storeRef = setupStore(undefined, true)
+        return storeRef
+          .dispatch<any>(apiSlice.endpoints.alderspensjonEnkel.initiate(body))
           .then((result: FetchBaseQueryError) => {
-            expect(result).toThrow(Error)
+            expect(result.status).toBe('fulfilled')
+            expect(result.data).toMatchObject(alderspensjonResponse)
+          })
+      })
+
+      it('returnerer undefined ved feilende query', async () => {
+        const storeRef = setupStore(undefined, true)
+        mockErrorResponse('/v1/alderspensjon/simulering', {
+          method: 'post',
+        })
+        return storeRef
+          .dispatch<any>(apiSlice.endpoints.alderspensjonEnkel.initiate(body))
+          .then((result: FetchBaseQueryError) => {
             expect(result.status).toBe('rejected')
             expect(result.data).toBe(undefined)
           })
+      })
+
+      it('kaster feil ved uventet format på responsen', async () => {
+        const storeRef = setupStore(undefined, true)
+        mockResponse('/v1/alderspensjon/simulering', {
+          status: 200,
+          json: [{ 'tullete svar': 'lorem' }],
+          method: 'post',
+        })
+        await swallowErrorsAsync(async () => {
+          await storeRef
+            .dispatch<any>(apiSlice.endpoints.alderspensjonEnkel.initiate(body))
+            .then((result: FetchBaseQueryError) => {
+              expect(result).toThrow(Error)
+              expect(result.status).toBe('rejected')
+              expect(result.data).toBe(undefined)
+            })
+        })
+      })
+    })
+    describe('avansert', () => {
+      const body: AlderspensjonRequestBody = {
+        simuleringstype: 'ALDERSPENSJON_MED_AFP_PRIVAT',
+        foedselsdato: '1963-04-30',
+        sivilstand: 'UGIFT',
+        epsHarInntektOver2G: true,
+        heltUttak: {
+          uttaksalder: { aar: 67, maaneder: 8 },
+        },
+      }
+      it('returnerer data ved vellykket query', async () => {
+        const storeRef = setupStore(undefined, true)
+        return storeRef
+          .dispatch<any>(apiSlice.endpoints.alderspensjon.initiate(body))
+          .then((result: FetchBaseQueryError) => {
+            expect(result.status).toBe('fulfilled')
+            expect(result.data).toMatchObject(alderspensjonResponse)
+          })
+      })
+
+      it('returnerer undefined ved feilende query', async () => {
+        const storeRef = setupStore(undefined, true)
+        mockErrorResponse('/v2/alderspensjon/simulering', {
+          method: 'post',
+        })
+        return storeRef
+          .dispatch<any>(apiSlice.endpoints.alderspensjon.initiate(body))
+          .then((result: FetchBaseQueryError) => {
+            expect(result.status).toBe('rejected')
+            expect(result.data).toBe(undefined)
+          })
+      })
+
+      it('kaster feil ved uventet format på responsen', async () => {
+        const storeRef = setupStore(undefined, true)
+        mockResponse('/v2/alderspensjon/simulering', {
+          status: 200,
+          json: [{ 'tullete svar': 'lorem' }],
+          method: 'post',
+        })
+        await swallowErrorsAsync(async () => {
+          await storeRef
+            .dispatch<any>(apiSlice.endpoints.alderspensjon.initiate(body))
+            .then((result: FetchBaseQueryError) => {
+              expect(result).toThrow(Error)
+              expect(result.status).toBe('rejected')
+              expect(result.data).toBe(undefined)
+            })
+        })
       })
     })
   })

--- a/src/state/api/apiSlice.ts
+++ b/src/state/api/apiSlice.ts
@@ -96,12 +96,35 @@ export const apiSlice = createApi({
       },
     }),
 
+    alderspensjonEnkel: builder.query<
+      AlderspensjonResponseBody,
+      AlderspensjonEnkelRequestBody
+    >({
+      query: (body) => ({
+        url: '/v1/alderspensjon/simulering',
+        method: 'POST',
+        body,
+      }),
+      providesTags: ['Alderspensjon'],
+      transformResponse: (response: AlderspensjonResponseBody) => {
+        if (
+          !isPensjonsberegningArray(response?.alderspensjon) ||
+          !isPensjonsberegningArray(response?.afpPrivat)
+        ) {
+          throw new Error(
+            `Mottok ugyldig alderspensjon: ${response?.alderspensjon}`
+          )
+        }
+        return response
+      },
+    }),
+
     alderspensjon: builder.query<
       AlderspensjonResponseBody,
       AlderspensjonRequestBody
     >({
       query: (body) => ({
-        url: '/v1/alderspensjon/simulering',
+        url: '/v2/alderspensjon/simulering',
         method: 'POST',
         body,
       }),
@@ -168,6 +191,7 @@ export const {
   useGetSakStatusQuery,
   useGetTpoMedlemskapQuery,
   useTidligsteUttaksalderQuery,
+  useAlderspensjonEnkelQuery,
   useAlderspensjonQuery,
   usePensjonsavtalerQuery,
   useGetSpraakvelgerFeatureToggleQuery,

--- a/src/state/api/utils.ts
+++ b/src/state/api/utils.ts
@@ -4,23 +4,44 @@ import { format, parseISO } from 'date-fns'
 export const generatePensjonsavtalerRequestBody = (
   aarligInntektFoerUttak: number,
   afp: AfpRadio | null,
-  uttaksalder: Alder | null,
-  sivilstand?: Sivilstand
+  heltUttak: HeltUttaksperiode,
+  sivilstand?: Sivilstand,
+  gradertUttak?: GradertUttaksperiode
 ): PensjonsavtalerRequestBody => {
   return {
     aarligInntektFoerUttak,
     uttaksperioder: [
+      ...(gradertUttak
+        ? [
+            {
+              startAlder: {
+                aar: gradertUttak.uttaksalder.aar,
+                maaneder:
+                  gradertUttak.uttaksalder.maaneder > 0
+                    ? gradertUttak.uttaksalder.maaneder
+                    : 0,
+              },
+              grad: gradertUttak.grad,
+              aarligInntekt: gradertUttak.aarligInntektVsaPensjon
+                ? gradertUttak.aarligInntektVsaPensjon
+                : 0,
+            },
+          ]
+        : []),
+
       {
         startAlder: {
-          aar: uttaksalder?.aar ?? 0,
+          aar: heltUttak.uttaksalder.aar ?? 0,
           maaneder:
-            uttaksalder && uttaksalder.maaneder > 0 ? uttaksalder.maaneder : 0,
+            heltUttak.uttaksalder.maaneder > 0
+              ? heltUttak.uttaksalder.maaneder
+              : 0,
         },
-        grad: 100, // Hardkodet til 100 for nå - brukeren kan ikke velge gradert pensjon
-        aarligInntekt: 0, // Hardkodet til 0 for nå - brukeren kan ikke legge til inntekt vsa. pensjon
+        grad: 100,
+        aarligInntekt: heltUttak.aarligInntektVsaPensjon ?? 0,
       },
     ],
-    antallInntektsaarEtterUttak: 0,
+    antallInntektsaarEtterUttak: 0, // TODO legge til logikk for beregning av antall år etter uttak
     harAfp: afp === 'ja_privat',
     // harEpsPensjon: Bruker kan angi om E/P/S har pensjon (støttes i detaljert kalkulator) – her bruker backend hardkodet false i MVP
     // harEpsPensjonsgivendeInntektOver2G: Bruker kan angi om E/P/S har inntekt >2G (støttes i detaljert kalkulator) – her bruker backend true i MVP hvis samboer/gift
@@ -35,8 +56,54 @@ export const generateAlderspensjonRequestBody = (args: {
   harSamboer: boolean | null
   foedselsdato: string | null | undefined
   aarligInntektFoerUttak: number
-  startAlder: Alder | null
+  gradertUttak?: GradertUttaksperiode
+  heltUttak?: HeltUttaksperiode
 }): AlderspensjonRequestBody | undefined => {
+  const {
+    afp,
+    sivilstand,
+    harSamboer,
+    foedselsdato,
+    aarligInntektFoerUttak,
+    gradertUttak,
+    heltUttak,
+  } = args
+
+  if (!foedselsdato || !heltUttak) {
+    return undefined
+  }
+
+  return {
+    simuleringstype:
+      afp === 'ja_privat' ? 'ALDERSPENSJON_MED_AFP_PRIVAT' : 'ALDERSPENSJON',
+    foedselsdato: format(parseISO(foedselsdato), 'yyyy-MM-dd'),
+    epsHarInntektOver2G: true, // Fast i MVP1 - Har ektefelle/partner/samboer inntekt over 2 ganger grunnbeløpet
+    aarligInntekt: aarligInntektFoerUttak,
+    sivilstand:
+      sivilstand && checkHarSamboer(sivilstand)
+        ? sivilstand
+        : harSamboer
+          ? 'SAMBOER'
+          : 'UGIFT',
+    gradertUttak,
+    heltUttak: {
+      ...heltUttak,
+      inntektTomAlder: {
+        aar: 75, // TODO hardkodet for nå - må legge til felt for sluttdato - hvordan velger man livsvarig, kan denne være optional?
+        maaneder: 0,
+      },
+    },
+  }
+}
+
+export const generateAlderspensjonEnkelRequestBody = (args: {
+  afp: AfpRadio | null
+  sivilstand?: Sivilstand | null | undefined
+  harSamboer: boolean | null
+  foedselsdato: string | null | undefined
+  aarligInntektFoerUttak: number
+  startAlder: Alder | null
+}): AlderspensjonEnkelRequestBody | undefined => {
   const {
     afp,
     sivilstand,

--- a/src/state/userInput/__tests__/selectors.test.ts
+++ b/src/state/userInput/__tests__/selectors.test.ts
@@ -20,10 +20,10 @@ describe('userInput selectors', () => {
   const initialState = store.getState()
 
   const currentSimulation: Simulation = {
-    uttaksperioder: [],
     formatertUttaksalderReadOnly: '62 alder.aar string.og 5 alder.maaneder',
     startAlder: { aar: 62, maaneder: 5 },
     aarligInntektFoerUttak: 0,
+    gradertUttaksperiode: null,
   }
 
   it('selectUtenlandsopphold', () => {

--- a/src/state/userInput/__tests__/userInputReducer.test.ts
+++ b/src/state/userInput/__tests__/userInputReducer.test.ts
@@ -65,10 +65,10 @@ describe('userInputSlice', () => {
       expect(updatedState).toStrictEqual({
         ...userInputInitialState,
         currentSimulation: {
-          uttaksperioder: [],
           formatertUttaksalderReadOnly: null,
           startAlder: { aar: 65, maaneder: 4 },
           aarligInntektFoerUttak: null,
+          gradertUttaksperiode: null,
         },
       })
     })
@@ -98,37 +98,43 @@ describe('userInputSlice', () => {
         ...userInputInitialState,
         currentSimulation: {
           ...userInputInitialState.currentSimulation,
-          aarligInntektVedSidenAvPensjon: 800000,
+          aarligInntektVsaPensjon: 800000,
         },
       })
     })
 
-    it('setCurrentSimulationUttaksperioder', () => {
+    it('setCurrentSimulationGradertuttaksperiode', () => {
       const updatedState = userInputSlice(
         userInputInitialState,
-        userInputActions.setCurrentSimulationUttaksperioder([
-          { startAlder: { aar: 67, maaneder: 3 }, grad: 20 },
-        ])
+        userInputActions.setCurrentSimulationGradertuttaksperiode({
+          uttaksalder: { aar: 67, maaneder: 3 },
+          grad: 20,
+          aarligInntektVsaPensjon: 150000,
+        })
       )
 
       expect(updatedState).toStrictEqual({
         ...userInputInitialState,
         currentSimulation: {
           ...userInputInitialState.currentSimulation,
-          uttaksperioder: [{ startAlder: { aar: 67, maaneder: 3 }, grad: 20 }],
+          gradertUttaksperiode: {
+            uttaksalder: { aar: 67, maaneder: 3 },
+            grad: 20,
+            aarligInntektVsaPensjon: 150000,
+          },
         },
       })
 
       const updatedState2 = userInputSlice(
         updatedState,
-        userInputActions.setCurrentSimulationUttaksperioder([])
+        userInputActions.setCurrentSimulationGradertuttaksperiode(null)
       )
 
       expect(updatedState2).toStrictEqual({
         ...userInputInitialState,
         currentSimulation: {
           ...userInputInitialState.currentSimulation,
-          uttaksperioder: [],
+          gradertUttaksperiode: null,
         },
       })
     })
@@ -160,11 +166,11 @@ describe('userInputSlice', () => {
           afp: 'ja_offentlig',
           samboer: false,
           currentSimulation: {
-            uttaksperioder: [],
             formatertUttaksalderReadOnly:
               '66 alder.aar string.og 4 alder.maaneder',
             startAlder: { aar: 66, maaneder: 4 },
             aarligInntektFoerUttak: 300000,
+            gradertUttaksperiode: null,
           },
         },
         userInputActions.flush()
@@ -185,11 +191,11 @@ describe('userInputSlice', () => {
           samboer: false,
 
           currentSimulation: {
-            uttaksperioder: [],
             formatertUttaksalderReadOnly:
               '66 alder.aar string.og 4 alder.maaneder',
             startAlder: { aar: 66, maaneder: 4 },
             aarligInntektFoerUttak: 300000,
+            gradertUttaksperiode: null,
           },
         },
         userInputActions.flushCurrentSimulation()

--- a/src/state/userInput/userInputReducer.ts
+++ b/src/state/userInput/userInputReducer.ts
@@ -1,17 +1,11 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
-export interface Uttaksperiode {
-  startAlder: Alder | null // valgt uttaksalder for perioden (alder perioden gjelder FRA) - aar heltall, maaneder heltall mellom 0-11
-  grad: number // optional: grad av alderspensjon i perioden
-  aarligInntekt?: number // optional: inntekt ved siden av pensjon i perioden
-}
-
 export interface Simulation {
-  uttaksperioder: Uttaksperiode[]
   formatertUttaksalderReadOnly: string | null // (!) Obs READONLY - string i format "YY alder.aar string.og M alder.maaneder" - oppdateres automatisk basert på startAlder - se uttaksalderListener
   startAlder: Alder | null // valgt uttaksalder for 100% alderspensjon (alder perioden gjelder FRA) - aar heltall, maaneder heltall mellom 0-11
   aarligInntektFoerUttak: number | null // inntekt før uttak av pensjon - heltall beløp i nok - overskriver beløp fra Skatteetaten
-  aarligInntektVedSidenAvPensjon?: number // optional: heltall beløp i nok - inntekt vsa. pensjon
+  aarligInntektVsaPensjon?: number // optional: heltall beløp i nok - inntekt vsa. pensjon
+  gradertUttaksperiode: GradertUttaksperiode | null
 }
 
 export interface UserInputState {
@@ -28,10 +22,10 @@ export const userInputInitialState: UserInputState = {
   afp: null,
   samboer: null,
   currentSimulation: {
-    uttaksperioder: [],
     formatertUttaksalderReadOnly: null,
     startAlder: null,
     aarligInntektFoerUttak: null,
+    gradertUttaksperiode: null,
   },
 }
 
@@ -73,13 +67,13 @@ export const userInputSlice = createSlice({
       state,
       action: PayloadAction<number | undefined>
     ) => {
-      state.currentSimulation.aarligInntektVedSidenAvPensjon = action.payload
+      state.currentSimulation.aarligInntektVsaPensjon = action.payload
     },
-    setCurrentSimulationUttaksperioder: (
+    setCurrentSimulationGradertuttaksperiode: (
       state,
-      action: PayloadAction<Uttaksperiode[]>
+      action: PayloadAction<GradertUttaksperiode | null>
     ) => {
-      state.currentSimulation.uttaksperioder = action.payload
+      state.currentSimulation.gradertUttaksperiode = action.payload
     },
     syncCurrentSimulationFormatertUttaksalderReadOnly: (
       state,

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -4,6 +4,27 @@
  */
 
 export interface paths {
+  '/api/v2/alderspensjon/simulering': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Simuler alderspensjon
+     *
+     * @description Lag en prognose for framtidig alderspensjon. Feltet 'epsHarInntektOver2G' brukes til å angi om ektefelle/partner/samboer har inntekt over 2 ganger grunnbeløpet eller ei.
+     */
+    post: operations['simulerAlderspensjon']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/api/v1/tidligste-uttaksalder': {
     parameters: {
       query?: never
@@ -56,11 +77,11 @@ export interface paths {
     get?: never
     put?: never
     /**
-     * Simuler alderspensjon
+     * Simuler hel alderspensjon
      *
-     * @description Lag en prognose for framtidig alderspensjon. Feltet 'epsHarInntektOver2G' brukes til å angi om ektefelle/partner/samboer har inntekt over 2 ganger grunnbeløpet eller ei.
+     * @description Lag en prognose for framtidig alderspensjon med 100 % uttak. Feltet 'epsHarInntektOver2G' brukes til å angi om ektefelle/partner/samboer har inntekt over 2 ganger grunnbeløpet eller ei.
      */
-    post: operations['simulerAlderspensjon']
+    post: operations['simulerAlderspensjonV1']
     delete?: never
     options?: never
     head?: never
@@ -239,6 +260,70 @@ export interface paths {
 export type webhooks = Record<string, never>
 export interface components {
   schemas: {
+    AlderIngressDto: {
+      /** Format: int32 */
+      aar: number
+      /** Format: int32 */
+      maaneder: number
+    }
+    SimuleringGradertUttakIngressDto: {
+      uttaksalder: components['schemas']['AlderIngressDto']
+      /** Format: int32 */
+      grad: number
+      /** Format: int32 */
+      aarligInntektVsaPensjon?: number
+    }
+    SimuleringHeltUttakIngressDto: {
+      uttaksalder: components['schemas']['AlderIngressDto']
+      inntektTomAlder?: components['schemas']['AlderIngressDto']
+      /** Format: int32 */
+      aarligInntektVsaPensjon?: number
+    }
+    SimuleringIngressSpecDto: {
+      /** @enum {string} */
+      simuleringstype: 'ALDERSPENSJON' | 'ALDERSPENSJON_MED_AFP_PRIVAT'
+      /** Format: date */
+      foedselsdato: string
+      epsHarInntektOver2G: boolean
+      /** Format: int32 */
+      aarligInntekt?: number
+      /** @enum {string} */
+      sivilstand?:
+        | 'UNKNOWN'
+        | 'UOPPGITT'
+        | 'UGIFT'
+        | 'GIFT'
+        | 'ENKE_ELLER_ENKEMANN'
+        | 'SKILT'
+        | 'SEPARERT'
+        | 'REGISTRERT_PARTNER'
+        | 'SEPARERT_PARTNER'
+        | 'SKILT_PARTNER'
+        | 'GJENLEVENDE_PARTNER'
+        | 'SAMBOER'
+      gradertUttak?: components['schemas']['SimuleringGradertUttakIngressDto']
+      heltUttak: components['schemas']['SimuleringHelttUttakIngressDto']
+    }
+    PensjonsberegningDto: {
+      /** Format: int32 */
+      alder: number
+      /** Format: int32 */
+      beloep: number
+    }
+    SimuleringsresultatDto: {
+      alderspensjon: components['schemas']['PensjonsberegningDto'][]
+      afpPrivat: components['schemas']['PensjonsberegningDto'][]
+      vilkaarErOppfylt: boolean
+    }
+    UttaksalderGradertUttakIngressDto: {
+      /** Format: int32 */
+      uttaksgrad: number
+      /** Format: int32 */
+      inntektUnderGradertUttak?: number
+      heltUttakAlder: components['schemas']['AlderIngressDto']
+      /** Format: date */
+      foedselsdato: string
+    }
     UttaksalderIngressSpecDto: {
       /** @enum {string} */
       sivilstand?:
@@ -259,6 +344,7 @@ export interface components {
       sisteInntekt?: number
       /** @enum {string} */
       simuleringstype?: 'ALDERSPENSJON' | 'ALDERSPENSJON_MED_AFP_PRIVAT'
+      gradertUttak?: components['schemas']['UttaksalderGradertUttakIngressDto']
     }
     AlderDto: {
       /** Format: int32 */
@@ -338,18 +424,12 @@ export interface components {
       /** Format: int32 */
       grad: number
     }
-    SimuleringAlderDto: {
-      /** Format: int32 */
-      aar: number
-      /** Format: int32 */
-      maaneder: number
-    }
     SimuleringSpecDto: {
       /** @enum {string} */
       simuleringstype: 'ALDERSPENSJON' | 'ALDERSPENSJON_MED_AFP_PRIVAT'
       /** Format: int32 */
       uttaksgrad: number
-      foersteUttaksalder: components['schemas']['SimuleringAlderDto']
+      foersteUttaksalder: components['schemas']['AlderIngressDto']
       /** Format: date */
       foedselsdato: string
       epsHarInntektOver2G: boolean
@@ -369,17 +449,6 @@ export interface components {
         | 'SKILT_PARTNER'
         | 'GJENLEVENDE_PARTNER'
         | 'SAMBOER'
-    }
-    PensjonsberegningDto: {
-      /** Format: int32 */
-      alder: number
-      /** Format: int32 */
-      beloep: number
-    }
-    SimuleringsresultatDto: {
-      alderspensjon: components['schemas']['PensjonsberegningDto'][]
-      afpPrivat: components['schemas']['PensjonsberegningDto'][]
-      vilkaarErOppfylt: boolean
     }
     UfoerepensjonSpecDto: {
       /** Format: date */
@@ -437,6 +506,39 @@ export interface components {
 }
 export type $defs = Record<string, never>
 export interface operations {
+  simulerAlderspensjon: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SimuleringIngressSpecDto']
+      }
+    }
+    responses: {
+      /** @description Simulering utført (men dersom vilkår ikke oppfylt vil responsen ikke inneholde pensjonsbeløp). */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['SimuleringsresultatDto']
+        }
+      }
+      /** @description Simulering kunne ikke utføres av tekniske årsaker */
+      503: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': unknown
+        }
+      }
+    }
+  }
   finnTidligsteUttaksalder: {
     parameters: {
       query?: never
@@ -444,7 +546,7 @@ export interface operations {
       path?: never
       cookie?: never
     }
-    requestBody?: {
+    requestBody: {
       content: {
         'application/json': components['schemas']['UttaksalderIngressSpecDto']
       }
@@ -503,7 +605,7 @@ export interface operations {
       }
     }
   }
-  simulerAlderspensjon: {
+  simulerAlderspensjonV1: {
     parameters: {
       query?: never
       header?: never

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -36,9 +36,18 @@ declare global {
   type UtilgjengeligeSelskap = components['schemas']['SelskapDto']
 
   // / alderspensjon
-  type AlderspensjonRequestBody = components['schemas']['SimuleringSpecDto']
+  type AlderspensjonEnkelRequestBody =
+    components['schemas']['SimuleringSpecDto']
+  type AlderspensjonRequestBody =
+    components['schemas']['SimuleringIngressSpecDto']
   type AlderspensjonResponseBody =
     components['schemas']['SimuleringsresultatDto']
+
+  type HeltUttaksperiode =
+    components['schemas']['SimuleringHeltUttakIngressDto']
+  type GradertUttaksperiode =
+    components['schemas']['SimuleringGradertUttakIngressDto']
+
   type Simuleringstype =
     components['schemas']['SimuleringSpecDto']['simuleringstype']
   type Pensjonsberegning = {


### PR DESCRIPTION
- tilpasser til simuleringsendepunkt v2 ved og:
    -  lage ny funksjon `generateAlderspensjonRequestBody` (i tillegg til `generateAlderspensjonEnkelRequestBody`)
    -  legge til siste Swagger types manuelt i schema.d.ts
    - utvider types
- legger til gradert uttaksperiode i kall til pensjonsavtaler (oppdaterer `generatePensjonsavtalerRequestBody`)

(!) Obs v1 av simuleringsendepunktet er fortsatt i bruk for enkel simulering