### PR TITLE
Refactor TMU Pensjonskalkulator Enkel

### DIFF
--- a/src/components/RedigerAvansertBeregning/RedigerAvansertBeregning.tsx
+++ b/src/components/RedigerAvansertBeregning/RedigerAvansertBeregning.tsx
@@ -74,6 +74,7 @@ export const RedigerAvansertBeregning: React.FC<{
     uttaksalder,
     aarligInntektVsaHelPensjon,
     gradertUttaksperiode,
+    hasVilkaarIkkeOppfylt,
   })
 
   const [
@@ -92,7 +93,6 @@ export const RedigerAvansertBeregning: React.FC<{
   const {
     data: tidligstMuligHeltUttak,
     isError: isTidligstMuligHeltUttakError,
-    isSuccess: isTidligstMuligHeltUttakSuccess,
   } = useTidligstMuligHeltUttakQuery(tidligstMuligHeltUttakRequestBody, {
     skip: !tidligstMuligHeltUttakRequestBody || hasVilkaarIkkeOppfylt,
   })
@@ -124,7 +124,7 @@ export const RedigerAvansertBeregning: React.FC<{
   })
 
   const minAlderForHeltUttak = React.useMemo(() => {
-    if (localGradertUttak || isTidligstMuligHeltUttakSuccess) {
+    if (localGradertUttak || tidligstMuligHeltUttak) {
       const oppdatertMinAlder = getMinAlderTilHeltUttak({
         localGradertUttak: localGradertUttak?.uttaksalder,
         tidligstMuligHeltUttak,
@@ -144,11 +144,7 @@ export const RedigerAvansertBeregning: React.FC<{
       }
       return oppdatertMinAlder
     }
-  }, [
-    localGradertUttak,
-    tidligstMuligHeltUttak,
-    isTidligstMuligHeltUttakSuccess,
-  ])
+  }, [localGradertUttak, tidligstMuligHeltUttak])
 
   const handleUttaksgradChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     resetValidationErrors()

--- a/src/components/RedigerAvansertBeregning/__tests__/RedigerAvansertBeregning-hooks.test.tsx
+++ b/src/components/RedigerAvansertBeregning/__tests__/RedigerAvansertBeregning-hooks.test.tsx
@@ -549,6 +549,33 @@ describe('RedigerAvansertBeregning-hooks', () => {
         ).toHaveTextContent(`FALSE`)
       })
     })
+
+    it('Når hasVilkaarIkkeOppfylt er true, blir hasUnsavedChanges false selv om andre verider har endret seg', async () => {
+      const { result } = renderHook(useFormLocalState, {
+        wrapper,
+        initialProps: {
+          ...initialProps,
+          hasVilkaarIkkeOppfylt: true,
+        },
+      })
+
+      // harAvansertSkjemaUnsavedChanges
+      expect(
+        await screen.findByTestId('harAvansertSkjemaUnsavedChanges')
+      ).toHaveTextContent(`FALSE`)
+
+      const { setLocalInntektFremTilUttak } = result.current[3]
+
+      act(() => {
+        setLocalInntektFremTilUttak(800000)
+      })
+      // harAvansertSkjemaUnsavedChanges
+      expect(
+        await screen.findByTestId('harAvansertSkjemaUnsavedChanges')
+      ).toHaveTextContent(`FALSE`)
+      // localInntektFremTilUttak
+      expect(result.current[0]).toBe(800000)
+    })
   })
 
   describe('useTidligstMuligUttakRequestBodyState', () => {

--- a/src/components/RedigerAvansertBeregning/hooks.tsx
+++ b/src/components/RedigerAvansertBeregning/hooks.tsx
@@ -16,12 +16,14 @@ export const useFormLocalState = (initialValues: {
   uttaksalder: Alder | null
   aarligInntektVsaHelPensjon: AarligInntektVsaPensjon | undefined
   gradertUttaksperiode: GradertUttak | null
+  hasVilkaarIkkeOppfylt?: boolean
 }) => {
   const {
     aarligInntektFoerUttakBeloepFraBrukerInput,
     uttaksalder,
     aarligInntektVsaHelPensjon,
     gradertUttaksperiode,
+    hasVilkaarIkkeOppfylt,
   } = initialValues
 
   const { setHarAvansertSkjemaUnsavedChanges } =
@@ -90,13 +92,14 @@ export const useFormLocalState = (initialValues: {
       JSON.stringify(aarligInntektVsaHelPensjon?.sluttAlder)
 
     const updatedHasUnsavedChanges =
-      hasInntektFremTilUnntakChanged ||
-      hasGradChanged ||
-      hasGradertUttaksalderChanged ||
-      hasAarligInntektVsaGradertPensjonChanged ||
-      hasUttaksalderChanged ||
-      hasAarligInntektBeloepVsaHelPensjonChanged ||
-      hasAarligInntektSluttAlderVsaHelPensjonChanged
+      !hasVilkaarIkkeOppfylt &&
+      (hasInntektFremTilUnntakChanged ||
+        hasGradChanged ||
+        hasGradertUttaksalderChanged ||
+        hasAarligInntektVsaGradertPensjonChanged ||
+        hasUttaksalderChanged ||
+        hasAarligInntektBeloepVsaHelPensjonChanged ||
+        hasAarligInntektSluttAlderVsaHelPensjonChanged)
 
     setHarAvansertSkjemaUnsavedChanges((previous) => {
       return previous !== updatedHasUnsavedChanges
@@ -111,6 +114,7 @@ export const useFormLocalState = (initialValues: {
     localInntektFremTilUttak,
     localGradertUttak,
     localHeltUttak,
+    hasVilkaarIkkeOppfylt,
   ])
 
   const handlers = React.useMemo(

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -36,7 +36,7 @@ export const getHandlers = (baseUrl: string = API_PATH) => [
   }),
 
   http.post(`${baseUrl}/v1/tidligste-hel-uttaksalder`, async () => {
-    await delay(TEST_DELAY)
+    await delay(1500)
     return HttpResponse.json(tidligstMuligHeltUttakResponse)
   }),
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -36,7 +36,7 @@ export const getHandlers = (baseUrl: string = API_PATH) => [
   }),
 
   http.post(`${baseUrl}/v1/tidligste-hel-uttaksalder`, async () => {
-    await delay(1500)
+    await delay(TEST_DELAY)
     return HttpResponse.json(tidligstMuligHeltUttakResponse)
   }),
 

--- a/src/pages/Beregning/Beregning.tsx
+++ b/src/pages/Beregning/Beregning.tsx
@@ -6,23 +6,14 @@ import { BodyLong, Button, Modal, ToggleGroup } from '@navikt/ds-react'
 import Highcharts from 'highcharts'
 import HighchartsAccessibility from 'highcharts/modules/accessibility'
 
-import { Loader } from '@/components/common/Loader'
 import { LightBlueFooter } from '@/components/LightBlueFooter'
 import { paths } from '@/router/constants'
-import { apiSlice, useTidligstMuligHeltUttakQuery } from '@/state/api/apiSlice'
 import {
   useGetHighchartsAccessibilityPluginFeatureToggleQuery,
   useGetDetaljertFaneFeatureToggleQuery,
 } from '@/state/api/apiSlice'
-import { generateTidligstMuligHeltUttakRequestBody } from '@/state/api/utils'
 import { useAppDispatch } from '@/state/hooks'
 import { useAppSelector } from '@/state/hooks'
-import {
-  selectAfp,
-  selectSamboer,
-  selectSivilstand,
-  selectAarligInntektFoerUttakBeloep,
-} from '@/state/userInput/selectors'
 import { selectCurrentSimulation } from '@/state/userInput/selectors'
 import { userInputActions } from '@/state/userInput/userInputReducer'
 import { addSelfDestructingEventListener } from '@/utils/events'
@@ -44,12 +35,6 @@ export const Beregning: React.FC<Props> = ({ visning }) => {
   const navigate = useNavigate()
   const dispatch = useAppDispatch()
 
-  const harSamboer = useAppSelector(selectSamboer)
-  const sivilstand = useAppSelector(selectSivilstand)
-  const afp = useAppSelector(selectAfp)
-  const aarligInntektFoerUttakBeloep = useAppSelector(
-    selectAarligInntektFoerUttakBeloep
-  )
   const { uttaksalder } = useAppSelector(selectCurrentSimulation)
 
   const [showModal, setShowModal] = React.useState<boolean>(false)
@@ -58,24 +43,10 @@ export const Beregning: React.FC<Props> = ({ visning }) => {
   const [harAvansertSkjemaUnsavedChanges, setHarAvansertSkjemaUnsavedChanges] =
     React.useState<boolean>(false)
 
-  const [
-    tidligstMuligHeltUttakRequestBody,
-    setTidligstMuligHeltUttakRequestBody,
-  ] = React.useState<TidligstMuligHeltUttakRequestBody | undefined>(undefined)
-
   const { data: highchartsAccessibilityFeatureToggle } =
     useGetHighchartsAccessibilityPluginFeatureToggleQuery()
   const { data: detaljertFaneFeatureToggle } =
     useGetDetaljertFaneFeatureToggleQuery()
-
-  // Hent tidligst mulig uttaksalder
-  const {
-    data: tidligstMuligUttak,
-    isLoading: isTidligstMuligUttakLoading,
-    isError: isTidligstMuligUttakError,
-  } = useTidligstMuligHeltUttakQuery(tidligstMuligHeltUttakRequestBody, {
-    skip: !tidligstMuligHeltUttakRequestBody,
-  })
 
   React.useEffect(() => {
     /* c8 ignore next 3 */
@@ -127,32 +98,11 @@ export const Beregning: React.FC<Props> = ({ visning }) => {
     }
   }, [shouldShowModalBoolean])
 
-  React.useEffect(() => {
-    const requestBody = generateTidligstMuligHeltUttakRequestBody({
-      afp,
-      sivilstand: sivilstand,
-      harSamboer,
-      aarligInntektFoerUttakBeloep: aarligInntektFoerUttakBeloep ?? 0,
-    })
-    setTidligstMuligHeltUttakRequestBody(requestBody)
-  }, [afp, sivilstand, aarligInntektFoerUttakBeloep, harSamboer])
-
   const navigateToTab = (v: BeregningVisning) => {
     navigate(v === 'enkel' ? paths.beregningEnkel : paths.beregningDetaljert)
     dispatch(userInputActions.flushCurrentSimulation())
     setAvansertSkjemaModus('redigering')
     setHarAvansertSkjemaUnsavedChanges(false)
-
-    if (isTidligstMuligUttakError) {
-      dispatch(apiSlice.util.invalidateTags(['TidligstMuligHeltUttak']))
-      if (tidligstMuligHeltUttakRequestBody) {
-        dispatch(
-          apiSlice.endpoints.tidligstMuligHeltUttak.initiate(
-            tidligstMuligHeltUttakRequestBody
-          )
-        )
-      }
-    }
   }
 
   const onToggleChange = (v: string) => {
@@ -167,18 +117,6 @@ export const Beregning: React.FC<Props> = ({ visning }) => {
     } else {
       navigateToTab(v as BeregningVisning)
     }
-  }
-
-  if (isTidligstMuligUttakLoading) {
-    return (
-      <Loader
-        data-testid="uttaksalder-loader"
-        size="3xlarge"
-        title={intl.formatMessage({
-          id: 'beregning.loading',
-        })}
-      />
-    )
   }
 
   return (
@@ -254,9 +192,9 @@ export const Beregning: React.FC<Props> = ({ visning }) => {
         )}
         {visning === 'enkel' && (
           <BeregningEnkel
-            tidligstMuligUttak={
-              !isTidligstMuligUttakError ? tidligstMuligUttak : undefined
-            }
+          // tidligstMuligUttak={
+          //   !isTidligstMuligUttakError ? tidligstMuligUttak : undefined
+          // }
           />
         )}
         {visning === 'avansert' && <BeregningAvansert />}

--- a/src/pages/Beregning/Beregning.tsx
+++ b/src/pages/Beregning/Beregning.tsx
@@ -190,13 +190,7 @@ export const Beregning: React.FC<Props> = ({ visning }) => {
             </div>
           </div>
         )}
-        {visning === 'enkel' && (
-          <BeregningEnkel
-          // tidligstMuligUttak={
-          //   !isTidligstMuligUttakError ? tidligstMuligUttak : undefined
-          // }
-          />
-        )}
+        {visning === 'enkel' && <BeregningEnkel />}
         {visning === 'avansert' && <BeregningAvansert />}
         <div className={`${styles.background} ${styles.background__lightblue}`}>
           <div className={styles.container}>

--- a/src/pages/Beregning/BeregningAvansert.tsx
+++ b/src/pages/Beregning/BeregningAvansert.tsx
@@ -109,10 +109,10 @@ export const BeregningAvansert: React.FC = () => {
   }, [error])
 
   React.useEffect(() => {
-    if (alderspensjon && !alderspensjon?.vilkaarErOppfylt) {
+    if (!isFetching && alderspensjon && !alderspensjon?.vilkaarErOppfylt) {
       setAvansertSkjemaModus('redigering')
     }
-  }, [avansertSkjemaModus, alderspensjon])
+  }, [alderspensjon])
 
   const [
     isPensjonsavtalerAccordionItemOpen,

--- a/src/pages/Beregning/__tests__/Beregning.test.tsx
+++ b/src/pages/Beregning/__tests__/Beregning.test.tsx
@@ -8,7 +8,7 @@ import { mockResponse } from '@/mocks/server'
 import { paths } from '@/router/constants'
 import { userInputInitialState } from '@/state/userInput/userInputReducer'
 import * as userInputReducerUtils from '@/state/userInput/userInputReducer'
-import { fireEvent, render, screen, userEvent } from '@/test-utils'
+import { fireEvent, render, screen, userEvent, waitFor } from '@/test-utils'
 
 const previousWindow = window
 
@@ -374,9 +374,13 @@ describe('Beregning', () => {
   describe('Gitt at pensjonskalkulator er i "enkel" visning', () => {
     it('vises det riktig innhold', async () => {
       render(<Beregning visning="enkel" />)
-      expect(
-        await screen.findByText('velguttaksalder.title')
-      ).toBeInTheDocument()
+      expect(screen.getByTestId('uttaksalder-loader')).toBeVisible()
+      await waitFor(async () => {
+        expect(
+          screen.queryByTestId('uttaksalder-loader')
+        ).not.toBeInTheDocument()
+      })
+      expect(await screen.findByTestId('tidligst-mulig-uttak')).toBeVisible()
     })
   })
 

--- a/src/pages/Beregning/__tests__/BeregningEnkel.test.tsx
+++ b/src/pages/Beregning/__tests__/BeregningEnkel.test.tsx
@@ -9,6 +9,8 @@ import * as apiSliceUtils from '@/state/api/apiSlice'
 import { userInputInitialState } from '@/state/userInput/userInputReducer'
 import { render, screen, userEvent, waitFor } from '@/test-utils'
 
+const alderspensjonResponse = require('../../../mocks/data/alderspensjon/68.json')
+
 describe('BeregningEnkel', () => {
   const fakeApiCalls = {
     queries: {
@@ -37,6 +39,93 @@ describe('BeregningEnkel', () => {
       },
     },
   }
+
+  describe('Når tidligst mulig uttaksalder hentes', () => {
+    it('kalles endepunktet med riktig request body', async () => {
+      const initiateMock = vi.spyOn(
+        apiSliceUtils.apiSlice.endpoints.tidligstMuligHeltUttak,
+        'initiate'
+      )
+      render(<BeregningEnkel />, {
+        preloadedState: {
+          /* eslint-disable @typescript-eslint/ban-ts-comment */
+          // @ts-ignore
+          api: { ...fakeApiCalls },
+          userInput: {
+            ...userInputInitialState,
+            samtykke: true,
+            samboer: false,
+            afp: 'ja_privat',
+          },
+        },
+      })
+
+      expect(initiateMock).toHaveBeenCalledWith(
+        {
+          aarligInntektFoerUttakBeloep: 500000,
+          aarligInntektVsaPensjon: undefined,
+
+          harEps: false,
+          simuleringstype: 'ALDERSPENSJON_MED_AFP_PRIVAT',
+          sivilstand: 'UGIFT',
+        },
+        {
+          forceRefetch: undefined,
+          subscriptionOptions: {
+            pollingInterval: 0,
+            refetchOnFocus: undefined,
+            refetchOnReconnect: undefined,
+            skipPollingIfUnfocused: false,
+          },
+        }
+      )
+    })
+
+    it('viser loading og deretter riktig header, tekst og knapper', async () => {
+      render(<BeregningEnkel />)
+      expect(screen.getByTestId('uttaksalder-loader')).toBeVisible()
+      await waitFor(async () => {
+        expect(
+          screen.queryByTestId('uttaksalder-loader')
+        ).not.toBeInTheDocument()
+      })
+      expect(await screen.findByTestId('tidligst-mulig-uttak')).toBeVisible()
+      expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(1)
+      expect(screen.getAllByRole('button')).toHaveLength(12)
+    })
+
+    it('når kallet til TMU feiler, viser det feilmelding og alle knappene fra 62 år. Resten av siden er som vanlig', async () => {
+      mockErrorResponse('/v1/tidligste-hel-uttaksalder', {
+        method: 'post',
+      })
+      mockResponse('/v2/alderspensjon/simulering', {
+        status: 200,
+        method: 'post',
+        json: {
+          ...alderspensjonResponse,
+        },
+      })
+      render(<BeregningEnkel />, {
+        preloadedState: {
+          /* eslint-disable @typescript-eslint/ban-ts-comment */
+          // @ts-ignore
+          api: { ...fakeApiCalls },
+          userInput: {
+            ...userInputInitialState,
+            samtykke: true,
+            samboer: false,
+          },
+        },
+      })
+
+      expect(
+        await screen.findByText('tidligstmuliguttak.error')
+      ).toBeInTheDocument()
+
+      expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(1)
+      expect(screen.getAllByRole('button')).toHaveLength(15)
+    })
+  })
 
   describe('Når brukeren velger uttaksalder', () => {
     it('viser en loader mens beregning av alderspensjon pågår, oppdaterer valgt knapp og tegner graph, gitt at beregning av alderspensjon var vellykket', async () => {
@@ -206,7 +295,7 @@ describe('BeregningEnkel', () => {
       const alertBoks = await screen.findByTestId('alert-inntekt')
       expect(alertBoks).toBeVisible()
 
-      await user.click(await screen.findByText('63 alder.aar'))
+      await user.click(await screen.findByText('67 alder.aar'))
       expect(alertBoks).not.toBeVisible()
     })
 


### PR DESCRIPTION
- flytter kode relatert til henting av TMU under Enkel fane
Dette med hensikt om å skille logikken for TMU Enkel fra TMU avansert (på grunn av en loop som er skapt ved redirect fra avansert til enkel fane når TMU har feilet)