### PR TITLE
bugfix inntekt array

### DIFF
--- a/src/components/Simulering/Simulering.tsx
+++ b/src/components/Simulering/Simulering.tsx
@@ -193,14 +193,13 @@ export function Simulering(props: {
                         gradertUttaksperiode?.aarligInntektVsaPensjonBeloep,
                     }
                   : undefined,
-              heltUttak:
-                uttaksalder && aarligInntektVsaHelPensjon
-                  ? {
-                      fra: uttaksalder,
-                      til: aarligInntektVsaHelPensjon?.sluttAlder,
-                      beloep: aarligInntektVsaHelPensjon.beloep,
-                    }
-                  : undefined,
+              heltUttak: uttaksalder
+                ? {
+                    fra: uttaksalder,
+                    til: aarligInntektVsaHelPensjon?.sluttAlder,
+                    beloep: aarligInntektVsaHelPensjon?.beloep,
+                  }
+                : undefined,
               length: XAxis.length,
             }),
           } as SeriesOptionsType,

--- a/src/components/Simulering/__tests__/Simulering-utils.test.ts
+++ b/src/components/Simulering/__tests__/Simulering-utils.test.ts
@@ -101,7 +101,34 @@ describe('Simulering-utils', () => {
       })
     })
     describe('Når helt uttak er oppgitt', () => {
-      it('returnerer et riktig mappet array med riktig beløp før uttak, og verdi for inntekt vsa pensjon videre', () => {
+      it('uten inntekt vsa hel pensjon, returnerer et riktig mappet array med riktig beløp før uttak', () => {
+        expect(
+          processInntektArray({
+            inntektFoerUttakBeloep: 500000,
+            gradertUttak: undefined,
+            heltUttak: {
+              fra: { aar: 65, maaneder: 0 },
+              til: undefined,
+              beloep: undefined,
+            },
+            length: 5,
+          })
+        ).toEqual([500000, 0, 0, 0, 0])
+
+        expect(
+          processInntektArray({
+            inntektFoerUttakBeloep: 500000,
+            gradertUttak: undefined,
+            heltUttak: {
+              fra: { aar: 65, maaneder: 4 },
+              til: undefined,
+              beloep: undefined,
+            },
+            length: 5,
+          })
+        ).toEqual([500000, 166666.66666666666, 0, 0, 0])
+      })
+      it('med inntekt vsa hel pensjon, returnerer et riktig mappet array med riktig beløp før uttak, og verdi for inntekt vsa pensjon videre', () => {
         expect(
           processInntektArray({
             inntektFoerUttakBeloep: 500000,

--- a/src/components/Simulering/utils.ts
+++ b/src/components/Simulering/utils.ts
@@ -40,7 +40,7 @@ export const processInntektArray = (args: {
   heltUttak:
     | {
         fra: Alder
-        til: Alder
+        til: Alder | undefined
         beloep?: number
       }
     | undefined
@@ -48,7 +48,6 @@ export const processInntektArray = (args: {
   length: number
 }): number[] => {
   const { inntektFoerUttakBeloep, gradertUttak, heltUttak, length } = args
-
   const dataArray = new Array(length).fill(0)
   dataArray[0] = inntektFoerUttakBeloep
 
@@ -80,7 +79,9 @@ export const processInntektArray = (args: {
   if (heltUttak) {
     const { fra, til, beloep } = heltUttak
     const startAgeIndex = brekkpunktIndex ? brekkpunktIndex : 1
-    const endAgeIndex = startAgeIndex + (til.aar - fra.aar)
+    const endAgeIndex = til
+      ? startAgeIndex + (til.aar - fra.aar)
+      : dataArray.length
 
     const firstYearPartialAmount =
       brekkpunktIndex === undefined
@@ -97,7 +98,7 @@ export const processInntektArray = (args: {
       dataArray[i] += beloep ? beloep : 0
     }
 
-    if (til.maaneder > 0 && endAgeIndex + 1 < length) {
+    if (til && til.maaneder > 0 && endAgeIndex + 1 < length) {
       dataArray[endAgeIndex] += beloep ? (beloep / 12) * til.maaneder : 0
     }
   }

--- a/src/components/Simulering/utils.ts
+++ b/src/components/Simulering/utils.ts
@@ -40,7 +40,7 @@ export const processInntektArray = (args: {
   heltUttak:
     | {
         fra: Alder
-        til: Alder | undefined
+        til?: Alder
         beloep?: number
       }
     | undefined
@@ -48,6 +48,7 @@ export const processInntektArray = (args: {
   length: number
 }): number[] => {
   const { inntektFoerUttakBeloep, gradertUttak, heltUttak, length } = args
+
   const dataArray = new Array(length).fill(0)
   dataArray[0] = inntektFoerUttakBeloep
 


### PR DESCRIPTION
- fjerner sjekk om at inntekt vsa pensjon er oppgitt (det skal beregnes for alle, uansett)
- tilpasser logikken til undefined sluttAlder
- legger til ny test for å dekke dette tilfellet