### PR TITLE
Use 'ansatt' ingress

### DIFF
--- a/.nais/deploy-veiledning-catbox.yml
+++ b/.nais/deploy-veiledning-catbox.yml
@@ -10,7 +10,7 @@ metadata:
 spec:
   image: "{{ image }}"
   ingresses:
-    - https://pensjonskalkulator-veiledning-frontend-catbox.intern.dev.nav.no/pensjon/kalkulator
+    - https://pensjonskalkulator-veiledning-frontend-catbox.ansatt.dev.nav.no/pensjon/kalkulator
   port: 8080
   replicas:
     min: 1

--- a/.nais/deploy-veiledning-prod.yml
+++ b/.nais/deploy-veiledning-prod.yml
@@ -10,7 +10,7 @@ metadata:
 spec:
   image: "{{ image }}"
   ingresses:
-    - https://pensjonskalkulator.intern.nav.no/pensjon/kalkulator
+    - https://pensjonskalkulator.ansatt.nav.no/pensjon/kalkulator
   port: 8080
   replicas:
     min: 2

--- a/.nais/deploy-veiledning-sandbox.yml
+++ b/.nais/deploy-veiledning-sandbox.yml
@@ -10,7 +10,7 @@ metadata:
 spec:
   image: "{{ image }}"
   ingresses:
-    - https://pensjonskalkulator-veiledning-frontend-sandbox.intern.dev.nav.no/pensjon/kalkulator
+    - https://pensjonskalkulator-veiledning-frontend-sandbox.ansatt.dev.nav.no/pensjon/kalkulator
   port: 8080
   replicas:
     min: 2

--- a/.nais/deploy-veiledning-staging.yml
+++ b/.nais/deploy-veiledning-staging.yml
@@ -10,7 +10,7 @@ metadata:
 spec:
   image: "{{ image }}"
   ingresses:
-    - https://pensjonskalkulator-veiledning-frontend-staging.intern.dev.nav.no/pensjon/kalkulator
+    - https://pensjonskalkulator-veiledning-frontend-staging.ansatt.dev.nav.no/pensjon/kalkulator
   port: 8080
   replicas:
     min: 2


### PR DESCRIPTION
Dette vil gi fortsatt tilgang til veileder-appen uten naisdevice etter 21. mai 2024.
Ref. [Slack-melding](https://nav-it.slack.com/archives/C013XV66XHB/p1714640138094089)