### PR TITLE
PEK-738

### DIFF
--- a/src/components/InfoOmFremtidigVedtak/InfoOmFremtidigVedtak.tsx
+++ b/src/components/InfoOmFremtidigVedtak/InfoOmFremtidigVedtak.tsx
@@ -16,12 +16,7 @@ interface Props {
 export function InfoOmFremtidigVedtak({ loependeVedtak, isCentered }: Props) {
   const intl = useIntl()
 
-  if (
-    !loependeVedtak ||
-    !loependeVedtak?.harFremtidigLoependeVedtak ||
-    (loependeVedtak.alderspensjon?.grad === 0 &&
-      loependeVedtak.ufoeretrygd.grad === 100)
-  ) {
+  if (!loependeVedtak || !loependeVedtak?.harFremtidigLoependeVedtak) {
     return null
   }
 

--- a/src/components/InfoOmFremtidigVedtak/__tests__/InfoOmFremtidigVedtak.test.tsx
+++ b/src/components/InfoOmFremtidigVedtak/__tests__/InfoOmFremtidigVedtak.test.tsx
@@ -27,24 +27,6 @@ describe('InfoOmFremtidigVedtak', () => {
     expect(asFragment()).toMatchInlineSnapshot(`<DocumentFragment />`)
   })
 
-  it('Når brukeren har 100 % uføretrygd og vedtaket viser 0 % alderspensjon, returnerer null', () => {
-    const { asFragment } = render(
-      <InfoOmFremtidigVedtak
-        loependeVedtak={{
-          alderspensjon: {
-            grad: 0,
-            fom: '2020-10-02',
-          },
-          ufoeretrygd: {
-            grad: 100,
-          },
-          harFremtidigLoependeVedtak: true,
-        }}
-      />
-    )
-    expect(asFragment()).toMatchInlineSnapshot(`<DocumentFragment />`)
-  })
-
   it('Når vedtaket gjelder frem i tid, returnerer riktig tekst', () => {
     render(
       <InfoOmFremtidigVedtak


### PR DESCRIPTION
Justerer logikken slik at varsel for fremtidig vedtak vises for brukere med 0 alderspensjon og 100% uføretrygd