### PR TITLE
Aksel-komponenter respekterer valgt språk

### DIFF
--- a/src/context/LanguageProvider/LanguageProvider.tsx
+++ b/src/context/LanguageProvider/LanguageProvider.tsx
@@ -1,6 +1,8 @@
 import { ReactNode, useEffect, useState } from 'react'
 import { IntlProvider } from 'react-intl'
 
+import { Provider as AkselProvider } from '@navikt/ds-react'
+import { nb, nn, en } from '@navikt/ds-react/locales'
 import {
   setAvailableLanguages,
   onLanguageSelect,
@@ -18,6 +20,8 @@ import '@formatjs/intl-datetimeformat/locale-data/nb'
 import '@formatjs/intl-datetimeformat/locale-data/nn'
 
 import { getCookie, getTranslations, updateLanguage, setCookie } from './utils'
+
+const akselLocales: Record<Locales, typeof nb> = { nb, nn, en }
 
 interface Props {
   children: ReactNode
@@ -66,7 +70,9 @@ export function LanguageProvider({ children }: Props) {
       locale={languageCookie}
       messages={getTranslations(languageCookie)}
     >
-      {children}
+      <AkselProvider locale={akselLocales[languageCookie]}>
+        {children}
+      </AkselProvider>
     </IntlProvider>
   )
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
Eksempel:

![image](https://github.com/user-attachments/assets/43bacc95-7ac6-494a-b753-1773a8dde38a)


(`"moduleResolution": "bundler"` trengs for å kunne importere fra `@navikt/ds-react/locales`)