### PR TITLE
PEK-776: Cypress: 2 nye steg i ufoeretrygd.cy.ts ifm. mottar uføretrygd og >62 år

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
         if (browser.family === 'firefox') {
           launchOptions.preferences['ui.prefersReducedMotion'] = 1
         }
-        if (browser.family === 'chromium') {
+        if (browser.family === 'chromium' && browser.name !== 'electron') {
           launchOptions.args.push('--force-prefers-reduced-motion')
         }
         return launchOptions

--- a/cypress/e2e/pensjon/kalkulator/hovedhistorie.cy.ts
+++ b/cypress/e2e/pensjon/kalkulator/hovedhistorie.cy.ts
@@ -21,10 +21,6 @@ describe('Hovedhistorie', () => {
 
     describe('Hvis jeg ikke er i målgruppen for ny kalkulator eller ikke bør bruke kalkulatoren,', () => {
       it('forventer jeg tilgang til detaljert kalkulator og uinnlogget kalkulator.', () => {
-        Cypress.on('uncaught:exception', () => {
-          // prevents Cypress from failing when catching errors in uinnlogget kalkulator
-          return false
-        })
         cy.contains('button', 'Logg inn i pensjonskalkulator').should('exist')
         cy.contains('button', 'Logg inn i detaljert pensjonskalkulator').click()
 

--- a/cypress/e2e/pensjon/kalkulator/ufoeretrygd.cy.ts
+++ b/cypress/e2e/pensjon/kalkulator/ufoeretrygd.cy.ts
@@ -1,5 +1,6 @@
 import { format, sub } from 'date-fns'
 
+import loependeVedtakMock from '../../../fixtures/loepende-vedtak.json'
 import personMock from '../../../fixtures/person.json'
 
 const fødselsdatoEldreEnn62 = format(
@@ -23,6 +24,7 @@ describe('Med ufoeretrygd', () => {
           url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
         },
         {
+          ...loependeVedtakMock,
           ufoeretrygd: {
             grad: 100,
           },
@@ -50,6 +52,7 @@ describe('Med ufoeretrygd', () => {
           url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
         },
         {
+          ...loependeVedtakMock,
           ufoeretrygd: {
             grad: 100,
           },
@@ -196,6 +199,7 @@ describe('Med ufoeretrygd', () => {
           url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
         },
         {
+          ...loependeVedtakMock,
           ufoeretrygd: {
             grad: 100,
           },
@@ -224,6 +228,7 @@ describe('Med ufoeretrygd', () => {
           url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
         },
         {
+          ...loependeVedtakMock,
           ufoeretrygd: {
             grad: 100,
           },
@@ -267,6 +272,7 @@ describe('Med ufoeretrygd', () => {
           url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
         },
         {
+          ...loependeVedtakMock,
           ufoeretrygd: {
             grad: 75,
           },
@@ -313,6 +319,7 @@ describe('Med ufoeretrygd', () => {
           url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
         },
         {
+          ...loependeVedtakMock,
           ufoeretrygd: {
             grad: 100,
           },
@@ -379,6 +386,7 @@ describe('Med ufoeretrygd', () => {
           url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
         },
         {
+          ...loependeVedtakMock,
           ufoeretrygd: {
             grad: 40,
           },


### PR DESCRIPTION
https://jira.adeo.no/secure/Tests.jspa#/testCase/PEK-T10