### PR TITLE
Fiks inert-attributt i ShowMore

### DIFF
--- a/src/components/common/ShowMore/ShowMore.tsx
+++ b/src/components/common/ShowMore/ShowMore.tsx
@@ -204,8 +204,7 @@ export const ShowMore = forwardRef<ShowMoreRef, ShowMoreProps>(
         <div
           className="navds-show-more__content"
           style={isOpen ? {} : { height: collapsedHeight }}
-          // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60822
-          inert={isOpen ? undefined : ''}
+          inert={isOpen ? undefined : true}
         >
           {children}
         </div>


### PR DESCRIPTION
Det ser ut til at React 19 nå har fått offisiell støtte for `inert`-attributtet, slik at denne nå må settes til `true` i stedet for tom streng for å virke.