### PR TITLE
PEK-904: Fjern tekst "i privat sektor"

### DIFF
--- a/cypress/e2e/pensjon/kalkulator/ufoeretrygd.cy.ts
+++ b/cypress/e2e/pensjon/kalkulator/ufoeretrygd.cy.ts
@@ -101,7 +101,7 @@ describe('Med ufoeretrygd', () => {
         cy.contains('button', 'Neste').click()
         cy.contains('Uføretrygd og AFP (avtalefestet pensjon)').should('exist')
         cy.contains(
-          'Gå videre for å se alderspensjon fra Nav og pensjonsavtaler i privat sektor.'
+          'Gå videre for å se alderspensjon fra Nav og pensjonsavtaler.'
         ).should('exist')
         cy.contains('button', 'Neste').click()
       })
@@ -130,7 +130,7 @@ describe('Med ufoeretrygd', () => {
         cy.contains('button', 'Neste').click()
         cy.contains('Uføretrygd og AFP (avtalefestet pensjon)').should('exist')
         cy.contains(
-          'Gå videre for å se alderspensjon fra Nav og pensjonsavtaler i privat sektor.'
+          'Gå videre for å se alderspensjon fra Nav og pensjonsavtaler.'
         ).should('exist')
         cy.contains('button', 'Neste').click()
       })
@@ -162,7 +162,7 @@ describe('Med ufoeretrygd', () => {
         cy.contains('button', 'Neste').click()
         cy.contains('Uføretrygd og AFP (avtalefestet pensjon)').should('exist')
         cy.contains(
-          'Gå videre for å se alderspensjon fra Nav og pensjonsavtaler i privat sektor.'
+          'Gå videre for å se alderspensjon fra Nav og pensjonsavtaler.'
         ).should('exist')
         cy.contains('button', 'Neste').click()
       })

--- a/src/components/TidligstMuligUttaksalder/__tests__/TidligstMuligUttaksalder.test.tsx
+++ b/src/components/TidligstMuligUttaksalder/__tests__/TidligstMuligUttaksalder.test.tsx
@@ -42,7 +42,7 @@ describe('TidligstMuligUttaksalder', () => {
       ).not.toBeInTheDocument()
       expect(
         screen.getByText(
-          'Aldersgrensene vil øke gradvis fra 1964-kullet med en til to måneder per årskull,',
+          'Aldersgrensene vil øke gradvis fra 1964-kullet med én til to måneder per årskull,',
           {
             exact: false,
           }
@@ -81,7 +81,7 @@ describe('TidligstMuligUttaksalder', () => {
       ).toBeInTheDocument()
       expect(
         screen.getByText(
-          'Aldersgrensene vil øke gradvis fra 1964-kullet med en til to måneder per årskull,',
+          'Aldersgrensene vil øke gradvis fra 1964-kullet med én til to måneder per årskull,',
           {
             exact: false,
           }

--- a/src/components/stegvisning/Ufoere/__tests__/__snapshots__/Ufoere.test.tsx.snap
+++ b/src/components/stegvisning/Ufoere/__tests__/__snapshots__/Ufoere.test.tsx.snap
@@ -132,7 +132,7 @@ exports[`stegvisning - Ufoere > rendrer slik den skal 1`] = `
          Kalkulatoren beregner ikke AFP for deg som får uføretrygd.
         <br />
         <br />
-         Gå videre for å se alderspensjon fra Nav og pensjonsavtaler i privat sektor.
+         Gå videre for å se alderspensjon fra Nav og pensjonsavtaler.
       </p>
       <button
         class="_button_10fc87 navds-button navds-button--primary navds-button--medium"

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -267,7 +267,7 @@ const translations = {
   'stegvisning.ufoere.readmore_1.body':
     'To qualify for AFP, you cannot have received disability benefits from Nav after the month you turn 62. This applies regardless of whether you have received full or partial disability benefits, how long you have been on disability benefits, and how much you have received in disability benefits.{br}{br}If you are under 62, you must relinquish your disability benefits by the end of the month you turn 62 in order to receive AFP. Remember that all the other conditions for qualifying for AFP must also be met.',
   'stegvisning.ufoere.ingress':
-    'You can get help assessing your options. Contact your occupational pension scheme if you work in the public sector. <planleggePensjonLink>Contact Nav</planleggePensjonLink> if you work in the private sector. {br}{br} The calculator does not calculate AFP (contractual early retirement) for those receiving disability benefits. {br}{br} Proceed to view old-age pension from Nav and pension agreements in the private sector.',
+    'You can get help assessing your options. Contact your occupational pension scheme if you work in the public sector. <planleggePensjonLink>Contact Nav</planleggePensjonLink> if you work in the private sector. {br}{br} The calculator does not calculate AFP (contractual early retirement) for those receiving disability benefits. {br}{br} Proceed to view old-age pension from Nav and pension agreements.',
   'stegvisning.samtykke_offentlig_afp.title':
     'Consent for Nav to Calculate AFP (contractual pension)',
   'stegvisning.samtykke_offentlig_afp.ingress':

--- a/src/translations/nb.ts
+++ b/src/translations/nb.ts
@@ -266,7 +266,7 @@ const translations = {
   'stegvisning.ufoere.readmore_1.body':
     'For å ha rett til AFP, kan du ikke ha fått utbetalt uføretrygd fra Nav etter den måneden du fyller 62 år. Det gjelder uansett om du har mottatt hel eller gradert uføretrygd, hvor lenge du har hatt uføretrygd og hvor mye du har fått utbetalt i uføretrygd.{br}{br}Hvis du er under 62 år, må du altså si fra deg uføretrygden innen utgangen av måneden du fyller 62 år for å få utbetalt AFP. Husk at alle de andre vilkårene for å ha rett til AFP også må være oppfylt.',
   'stegvisning.ufoere.ingress':
-    'Du kan få hjelp til å vurdere alternativene dine. Kontakt tjenestepensjonsordningen din hvis du jobber i offentlig sektor. <planleggePensjonLink>Kontakt Nav</planleggePensjonLink> hvis du jobber i privat sektor. {br}{br} Kalkulatoren beregner ikke AFP for deg som får uføretrygd.{br}{br} Gå videre for å se alderspensjon fra Nav og pensjonsavtaler i privat sektor.',
+    'Du kan få hjelp til å vurdere alternativene dine. Kontakt tjenestepensjonsordningen din hvis du jobber i offentlig sektor. <planleggePensjonLink>Kontakt Nav</planleggePensjonLink> hvis du jobber i privat sektor. {br}{br} Kalkulatoren beregner ikke AFP for deg som får uføretrygd.{br}{br} Gå videre for å se alderspensjon fra Nav og pensjonsavtaler.',
   'stegvisning.samtykke_offentlig_afp.title':
     'Samtykke til at Nav beregner AFP (avtalefestet pensjon)',
   'stegvisning.samtykke_offentlig_afp.ingress':
@@ -328,7 +328,7 @@ const translations = {
   'beregning.read_more.pensjonsalder.body.optional':
     'Den oppgitte alderen er et estimat. ',
   'beregning.read_more.pensjonsalder.body':
-    'Din opptjening i folketrygden bestemmer når du kan ta ut alderspensjon. Aldersgrensene vil øke gradvis fra 1964-kullet med en til to måneder per årskull, men dette tar ikke pensjonskalkulatoren høyde for.{br}{br}Hvis du har oppgitt AFP og/eller utenlandsopphold, er dette med i vurderingen av når du kan ta ut alderspensjon.{br}{br}Hvis du ikke kan ta ut hel <nowrap>(100 %)</nowrap> alderspensjon fra ønsket alder, kan du endre uttaksgraden for å se om du kan starte tidligere. Tar du ut gradert pensjon, kan tidspunktet du kan ta ut <nowrap>100 %</nowrap> forskyves.',
+    'Din opptjening i folketrygden bestemmer når du kan ta ut alderspensjon. Aldersgrensene vil øke gradvis fra 1964-kullet med én til to måneder per årskull, men dette tar ikke pensjonskalkulatoren høyde for.{br}{br}Hvis du har oppgitt AFP og/eller utenlandsopphold, er dette med i vurderingen av når du kan ta ut alderspensjon.{br}{br}Hvis du ikke kan ta ut hel <nowrap>(100 %)</nowrap> alderspensjon fra ønsket alder, kan du endre uttaksgraden for å se om du kan starte tidligere. Tar du ut gradert pensjon, kan tidspunktet du kan ta ut <nowrap>100 %</nowrap> forskyves.',
   'beregning.read_more.pensjonsalder.endring.body':
     'Opptjeningen din i folketrygden bestemmer hvor mye alderspensjon du kan ta ut. Ved 67 år må pensjonen minst tilsvare garantipensjon. Uttak før 67 år betyr at du fordeler pensjonen din over flere år, og dermed får du mindre hvert år.{br}{br}Hvis du har AFP, er AFP med i vurderingen av hvor mye alderspensjon du kan ta ut.',
   'beregning.alt_tekst': 'Årlig inntekt og pensjon etter uttak i kroner.',


### PR DESCRIPTION
Justerte teksten `stegvisning.ufoere.ingress` ihht. PEK-904.

Fikset i samme slengen en liten skrivefeil jeg fant i `beregning.read_more.pensjonsalder.body`.