### PR TITLE
PEK-924

### DIFF
--- a/cypress/e2e/pensjon/kalkulator/endring.cy.ts
+++ b/cypress/e2e/pensjon/kalkulator/endring.cy.ts
@@ -5,7 +5,7 @@ describe('Endring av alderspensjon', () => {
         cy.intercept(
           {
             method: 'GET',
-            url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+            url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
           },
           { fixture: 'loepende-vedtak-endring.json' }
         ).as('getLoependeVedtak')
@@ -34,12 +34,13 @@ describe('Endring av alderspensjon', () => {
           cy.intercept(
             {
               method: 'GET',
-              url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+              url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
             },
             {
               alderspensjon: {
                 grad: 100,
                 fom: '2010-10-10',
+                sivilstand: 'UGIFT',
               },
               ufoeretrygd: {
                 grad: 0,
@@ -466,12 +467,13 @@ describe('Endring av alderspensjon', () => {
         cy.intercept(
           {
             method: 'GET',
-            url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+            url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
           },
           {
             alderspensjon: {
               grad: 80,
               fom: '2010-10-10',
+              sivilstand: 'UGIFT',
             },
             afpPrivat: { fom: '2010-10-10' },
             ufoeretrygd: {
@@ -505,12 +507,13 @@ describe('Endring av alderspensjon', () => {
           cy.intercept(
             {
               method: 'GET',
-              url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+              url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
             },
             {
               alderspensjon: {
                 grad: 80,
                 fom: '2010-10-10',
+                sivilstand: 'UGIFT',
               },
               afpPrivat: { fom: '2010-10-10' },
               ufoeretrygd: {
@@ -790,12 +793,13 @@ describe('Endring av alderspensjon', () => {
         cy.intercept(
           {
             method: 'GET',
-            url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+            url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
           },
           {
             alderspensjon: {
               grad: 80,
               fom: '2010-10-10',
+              sivilstand: 'UGIFT',
             },
             afpOffentlig: { fom: '2010-10-10' },
             ufoeretrygd: {
@@ -829,12 +833,13 @@ describe('Endring av alderspensjon', () => {
           cy.intercept(
             {
               method: 'GET',
-              url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+              url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
             },
             {
               alderspensjon: {
                 grad: 80,
                 fom: '2010-10-10',
+                sivilstand: 'UGIFT',
               },
               afpOffentlig: { fom: '2010-10-10' },
               ufoeretrygd: {
@@ -1115,12 +1120,13 @@ describe('Endring av alderspensjon', () => {
         cy.intercept(
           {
             method: 'GET',
-            url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+            url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
           },
           {
             alderspensjon: {
               grad: 50,
               fom: '2010-10-10',
+              sivilstand: 'UGIFT',
             },
             ufoeretrygd: {
               grad: 50,
@@ -1153,12 +1159,13 @@ describe('Endring av alderspensjon', () => {
           cy.intercept(
             {
               method: 'GET',
-              url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+              url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
             },
             {
               alderspensjon: {
                 grad: 50,
                 fom: '2010-10-10',
+                sivilstand: 'UGIFT',
               },
               ufoeretrygd: {
                 grad: 50,
@@ -1409,12 +1416,13 @@ describe('Endring av alderspensjon', () => {
         cy.intercept(
           {
             method: 'GET',
-            url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+            url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
           },
           {
             alderspensjon: {
               grad: 0,
               fom: '2010-10-10',
+              sivilstand: 'UGIFT',
             },
             ufoeretrygd: {
               grad: 100,
@@ -1447,12 +1455,13 @@ describe('Endring av alderspensjon', () => {
           cy.intercept(
             {
               method: 'GET',
-              url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+              url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
             },
             {
               alderspensjon: {
                 grad: 0,
                 fom: '2010-10-10',
+                sivilstand: 'UGIFT',
               },
               ufoeretrygd: {
                 grad: 100,

--- a/cypress/e2e/pensjon/kalkulator/hovedhistorie.cy.ts
+++ b/cypress/e2e/pensjon/kalkulator/hovedhistorie.cy.ts
@@ -91,7 +91,7 @@ describe('Hovedhistorie', () => {
           cy.intercept(
             {
               method: 'GET',
-              url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+              url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
             },
             {
               ...loependeVedtakMock,

--- a/cypress/e2e/pensjon/kalkulator/omstillingsstoenad-og-gjenlevende.cy.ts
+++ b/cypress/e2e/pensjon/kalkulator/omstillingsstoenad-og-gjenlevende.cy.ts
@@ -49,7 +49,7 @@ describe('med omstillingsstønad og gjenlevende', () => {
         cy.intercept(
           {
             method: 'GET',
-            url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+            url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
           },
           {
             ufoeretrygd: {

--- a/cypress/e2e/pensjon/kalkulator/ufoeretrygd.cy.ts
+++ b/cypress/e2e/pensjon/kalkulator/ufoeretrygd.cy.ts
@@ -21,7 +21,7 @@ describe('Med ufoeretrygd', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+          url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
         },
         {
           ...loependeVedtakMock,
@@ -49,7 +49,7 @@ describe('Med ufoeretrygd', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+          url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
         },
         {
           ...loependeVedtakMock,
@@ -196,7 +196,7 @@ describe('Med ufoeretrygd', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+          url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
         },
         {
           ...loependeVedtakMock,
@@ -225,7 +225,7 @@ describe('Med ufoeretrygd', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+          url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
         },
         {
           ...loependeVedtakMock,
@@ -269,7 +269,7 @@ describe('Med ufoeretrygd', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+          url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
         },
         {
           ...loependeVedtakMock,
@@ -316,7 +316,7 @@ describe('Med ufoeretrygd', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+          url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
         },
         {
           ...loependeVedtakMock,
@@ -383,7 +383,7 @@ describe('Med ufoeretrygd', () => {
       cy.intercept(
         {
           method: 'GET',
-          url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+          url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
         },
         {
           ...loependeVedtakMock,

--- a/cypress/fixtures/loepende-vedtak-endring.json
+++ b/cypress/fixtures/loepende-vedtak-endring.json
@@ -1,7 +1,8 @@
 {
   "alderspensjon": {
     "grad": 100,
-    "fom": "2010-10-10"
+    "fom": "2010-10-10",
+    "sivilstand": "UGIFT"
   },
   "ufoeretrygd": {
     "grad": 0

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -106,7 +106,7 @@ beforeEach(() => {
   cy.intercept(
     {
       method: 'GET',
-      url: '/pensjon/kalkulator/api/v2/vedtak/loepende-vedtak',
+      url: '/pensjon/kalkulator/api/v3/vedtak/loepende-vedtak',
     },
     { fixture: 'loepende-vedtak.json' }
   ).as('getLoependeVedtak')

--- a/src/components/EndreInntekt/__tests__/EndreInntekt.test.tsx
+++ b/src/components/EndreInntekt/__tests__/EndreInntekt.test.tsx
@@ -147,7 +147,7 @@ describe('EndreInntekt', () => {
 
   describe('Gitt at brukeren har uføretrygd', () => {
     it('viser riktig tekst', async () => {
-      mockResponse('/v2/vedtak/loepende-vedtak', {
+      mockResponse('/v3/vedtak/loepende-vedtak', {
         status: 200,
         json: {
           ufoeretrygd: {

--- a/src/components/Grunnlag/Grunnlag.tsx
+++ b/src/components/Grunnlag/Grunnlag.tsx
@@ -14,7 +14,7 @@ import { AccordionItem } from '@/components/common/AccordionItem'
 import { paths } from '@/router/constants'
 import { useGetPersonQuery } from '@/state/api/apiSlice'
 import { useAppDispatch, useAppSelector } from '@/state/hooks'
-import { selectSamboer } from '@/state/userInput/selectors'
+import { selectSamboer, selectSivilstand } from '@/state/userInput/selectors'
 import { userInputActions } from '@/state/userInput/userInputReducer'
 import { BeregningVisning } from '@/types/common-types'
 import { formatInntekt } from '@/utils/inntekt'
@@ -62,11 +62,12 @@ export const Grunnlag: React.FC<Props> = ({
 
   const { data: person, isSuccess } = useGetPersonQuery()
   const harSamboer = useAppSelector(selectSamboer)
+  const sivilstand = useAppSelector(selectSivilstand)
 
   const formatertSivilstand = React.useMemo(
     () =>
-      person
-        ? formatSivilstand(intl, person.sivilstand, {
+      sivilstand
+        ? formatSivilstand(intl, sivilstand, {
             harSamboer: !!harSamboer,
           })
         : '',

--- a/src/components/Grunnlag/__tests__/Grunnlag.test.tsx
+++ b/src/components/Grunnlag/__tests__/Grunnlag.test.tsx
@@ -1,5 +1,8 @@
 import { Grunnlag } from '@/components/Grunnlag'
-import { fulfilledGetLoependeVedtak0Ufoeregrad } from '@/mocks/mockedRTKQueryApiCalls'
+import {
+  fulfilledGetLoependeVedtak0Ufoeregrad,
+  fulfilledGetLoependeVedtakLoependeAlderspensjon,
+} from '@/mocks/mockedRTKQueryApiCalls'
 import { mockErrorResponse, mockResponse } from '@/mocks/server'
 import { paths } from '@/router/constants'
 import { userInputInitialState } from '@/state/userInput/userInputReducer'
@@ -143,7 +146,47 @@ describe('Grunnlag', () => {
   })
 
   describe('Grunnlag - sivilstand', () => {
-    it('viser riktig tekst og lenke når henting av sivilstand er vellykket', async () => {
+    it('viser riktig tekst og lenke når henting av sivilstand fra vedtaket er vellykket', async () => {
+      const user = userEvent.setup()
+
+      render(<Grunnlag headingLevel={'2'} visning={'avansert'} />, {
+        preloadedState: {
+          api: {
+            //@ts-ignore
+            queries: {
+              ...fulfilledGetLoependeVedtakLoependeAlderspensjon,
+            },
+          },
+          userInput: {
+            ...userInputInitialState,
+          },
+        },
+      })
+
+      expect(
+        await screen.findByText('grunnlag.sivilstand.title')
+      ).toBeInTheDocument()
+      expect(
+        await screen.findByText('sivilstand.ugift, sivilstand.uten_samboer')
+      ).toBeInTheDocument()
+      await waitFor(async () => {
+        expect(
+          screen.queryByText('grunnlag.sivilstand.title.error')
+        ).not.toBeInTheDocument()
+      })
+      const buttons = screen.getAllByRole('button')
+
+      await user.click(buttons[3])
+
+      expect(
+        await screen.findByText(
+          'Størrelsen på alderspensjonen din kan avhenge av om du bor alene eller sammen med noen. ',
+          { exact: false }
+        )
+      ).toBeVisible()
+    })
+
+    it('viser riktig tekst og lenke når henting av sivilstand fra person er vellykket', async () => {
       const user = userEvent.setup()
       mockResponse('/v4/person', {
         status: 200,

--- a/src/components/RedigerAvansertBeregning/__tests__/RedigerAvansertBeregning-utils.test.tsx
+++ b/src/components/RedigerAvansertBeregning/__tests__/RedigerAvansertBeregning-utils.test.tsx
@@ -578,7 +578,7 @@ describe('RedigerAvansertBeregning-utils', () => {
             alderspensjon: {
               fom: '2025-10-01',
               grad: 40,
-              sivilstand: 'UGIFT',
+              sivilstand: 'UGIFT' as Sivilstand,
             },
             ufoeretrygd: {
               grad: 0,

--- a/src/components/RedigerAvansertBeregning/__tests__/RedigerAvansertBeregning-utils.test.tsx
+++ b/src/components/RedigerAvansertBeregning/__tests__/RedigerAvansertBeregning-utils.test.tsx
@@ -507,6 +507,7 @@ describe('RedigerAvansertBeregning-utils', () => {
         alderspensjon: {
           fom: '2025-10-01',
           grad: 100,
+          sivilstand: 'UGIFT' as Sivilstand,
         },
         ufoeretrygd: {
           grad: 0,
@@ -577,6 +578,7 @@ describe('RedigerAvansertBeregning-utils', () => {
             alderspensjon: {
               fom: '2025-10-01',
               grad: 40,
+              sivilstand: 'UGIFT',
             },
             ufoeretrygd: {
               grad: 0,

--- a/src/components/RedigerAvansertBeregning/__tests__/RedigerAvansertBeregning.test.tsx
+++ b/src/components/RedigerAvansertBeregning/__tests__/RedigerAvansertBeregning.test.tsx
@@ -2329,6 +2329,7 @@ describe('RedigerAvansertBeregning', () => {
                     alderspensjon: {
                       grad: 100,
                       fom: new Date().toLocaleDateString('en-CA'), // dette gir dato i format yyyy-mm-dd
+                      sivilstand: 'UGIFT',
                     },
                     ufoeretrygd: {
                       grad: 0,

--- a/src/components/stegvisning/Start/__tests__/Start.test.tsx
+++ b/src/components/stegvisning/Start/__tests__/Start.test.tsx
@@ -64,6 +64,7 @@ describe('stegvisning - Start', () => {
           alderspensjon: {
             grad: 50,
             fom: '2020-10-02',
+            sivilstand: 'UGIFT',
           },
           ufoeretrygd: {
             grad: 0,
@@ -94,6 +95,7 @@ describe('stegvisning - Start', () => {
           alderspensjon: {
             grad: 50,
             fom: '2020-10-02',
+            sivilstand: 'UGIFT',
           },
           ufoeretrygd: {
             grad: 80,
@@ -127,6 +129,7 @@ describe('stegvisning - Start', () => {
           alderspensjon: {
             grad: 50,
             fom: '2020-10-02',
+            sivilstand: 'UGIFT',
           },
           ufoeretrygd: {
             grad: 0,
@@ -163,6 +166,7 @@ describe('stegvisning - Start', () => {
           alderspensjon: {
             grad: 50,
             fom: '2020-10-02',
+            sivilstand: 'UGIFT',
           },
           ufoeretrygd: {
             grad: 0,
@@ -225,6 +229,7 @@ describe('stegvisning - Start', () => {
           alderspensjon: {
             grad: 50,
             fom: '2020-10-02',
+            sivilstand: 'UGIFT',
           },
           ufoeretrygd: {
             grad: 0,

--- a/src/mocks/data/loepende-vedtak.json
+++ b/src/mocks/data/loepende-vedtak.json
@@ -1,4 +1,9 @@
 {
+  "alderspensjon": {
+    "grad": 100,
+    "fom": "2020-10-02",
+    "sivilstand": "UGIFT"
+  },
   "ufoeretrygd": {
     "grad": 0
   },

--- a/src/mocks/data/loepende-vedtak.json
+++ b/src/mocks/data/loepende-vedtak.json
@@ -1,9 +1,4 @@
 {
-  "alderspensjon": {
-    "grad": 100,
-    "fom": "2020-10-02",
-    "sivilstand": "UGIFT"
-  },
   "ufoeretrygd": {
     "grad": 0
   },

--- a/src/mocks/data/person.json
+++ b/src/mocks/data/person.json
@@ -1,6 +1,6 @@
 {
   "navn": "Aprikos",
-  "sivilstand": "UGIFT",
+  "sivilstand": "GIFT",
   "foedselsdato": "1963-04-30",
   "pensjoneringAldre": {
     "normertPensjoneringsalder": {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -65,7 +65,7 @@ export const getHandlers = (baseUrl: string = API_PATH) => [
     return HttpResponse.json(offentligTpResponse)
   }),
 
-  http.get(`${baseUrl}/v2/vedtak/loepende-vedtak`, async () => {
+  http.get(`${baseUrl}/v3/vedtak/loepende-vedtak`, async () => {
     await delay(TEST_DELAY)
     return HttpResponse.json(loependeVedtakResponse)
   }),

--- a/src/mocks/mockedRTKQueryApiCalls.ts
+++ b/src/mocks/mockedRTKQueryApiCalls.ts
@@ -152,6 +152,7 @@ export const fulfilledGetLoependeVedtakLoependeAlderspensjon = {
       alderspensjon: {
         grad: 100,
         fom: '2020-10-02',
+        sivilstand: 'UGIFT' as Sivilstand,
       },
       ufoeretrygd: {
         grad: 0,
@@ -177,6 +178,7 @@ export const fulfilledGetLoependeVedtakLoependeAlderspensjonMedSisteUtbetaling =
             beloep: 34000,
             utbetalingsdato: '2024-10-12',
           },
+          sivilstand: 'UGIFT' as Sivilstand,
         },
         ufoeretrygd: {
           grad: 0,
@@ -197,6 +199,7 @@ export const fulfilledGetLoependeVedtakLoepende50Alderspensjon = {
       alderspensjon: {
         grad: 50,
         fom: '2020-10-02',
+        sivilstand: 'UGIFT' as Sivilstand,
       },
       ufoeretrygd: {
         grad: 0,
@@ -217,6 +220,7 @@ export const fulfilledGetLoependeVedtakLoependeAlderspensjonOg40Ufoeretrygd = {
       alderspensjon: {
         grad: 100,
         fom: '2020-10-02',
+        sivilstand: 'UGIFT' as Sivilstand,
       },
       ufoeretrygd: {
         grad: 40,
@@ -237,6 +241,7 @@ export const fulfilledGetLoependeVedtakLoependeAFPprivat = {
       alderspensjon: {
         grad: 0,
         fom: '2020-10-02',
+        sivilstand: 'UGIFT' as Sivilstand,
       },
       ufoeretrygd: {
         grad: 0,
@@ -279,6 +284,7 @@ export const fulfilledGetLoependeVedtakLoepende0Alderspensjon100Ufoeretrygd = {
       alderspensjon: {
         grad: 0,
         fom: '2020-10-02',
+        sivilstand: 'UGIFT' as Sivilstand,
       },
       ufoeretrygd: {
         grad: 100,
@@ -315,6 +321,7 @@ export const fulfilledGetLoependeVedtakFremtidigMedAlderspensjon = {
       alderspensjon: {
         grad: 100,
         fom: '2020-10-02',
+        sivilstand: 'UGIFT' as Sivilstand,
       },
       ufoeretrygd: {
         grad: 0,

--- a/src/pages/Beregning/BeregningAvansert.tsx
+++ b/src/pages/Beregning/BeregningAvansert.tsx
@@ -28,6 +28,7 @@ import { useAppDispatch, useAppSelector } from '@/state/hooks'
 import {
   selectAfp,
   selectSamboer,
+  selectSivilstand,
   selectCurrentSimulation,
   selectSamtykkeOffentligAFP,
   selectAarligInntektFoerUttakBeloep,
@@ -53,6 +54,7 @@ export const BeregningAvansert: React.FC = () => {
     React.useContext(BeregningContext)
 
   const harSamboer = useAppSelector(selectSamboer)
+  const sivilstand = useAppSelector(selectSivilstand)
   const harSamtykketOffentligAFP = useAppSelector(selectSamtykkeOffentligAFP)
   const afp = useAppSelector(selectAfp)
   const isEndring = useAppSelector(selectIsEndring)
@@ -81,7 +83,7 @@ export const BeregningAvansert: React.FC = () => {
       const requestBody = generateAlderspensjonRequestBody({
         loependeVedtak,
         afp: afp === 'ja_offentlig' && !harSamtykketOffentligAFP ? null : afp,
-        sivilstand: person?.sivilstand,
+        sivilstand,
         harSamboer,
         foedselsdato: person?.foedselsdato,
         aarligInntektFoerUttakBeloep: aarligInntektFoerUttakBeloep ?? '0',

--- a/src/pages/StepStart/__tests__/StepStart.test.tsx
+++ b/src/pages/StepStart/__tests__/StepStart.test.tsx
@@ -109,12 +109,13 @@ describe('StepStart', () => {
 
   describe('Gitt at brukeren har et vedtak om alderspensjon eller AFP', () => {
     it('viser informasjon om dagens alderspensjon og AFP i tillegg til hilsen med navnet til brukeren', async () => {
-      mockResponse('/v2/vedtak/loepende-vedtak', {
+      mockResponse('/v3/vedtak/loepende-vedtak', {
         status: 200,
         json: {
           alderspensjon: {
             grad: 50,
             fom: '2020-10-02',
+            sivilstand: 'UGIFT',
           },
           ufoeretrygd: {
             grad: 0,
@@ -142,7 +143,7 @@ describe('StepStart', () => {
     })
 
     it('rendrer ikke siden når henting av loepende vedtak feiler og redirigerer til /uventet-feil', async () => {
-      mockErrorResponse('/v2/vedtak/loepende-vedtak')
+      mockErrorResponse('/v3/vedtak/loepende-vedtak')
       const mockedState = {
         api: {
           queries: {

--- a/src/router/__tests__/loaders.test.tsx
+++ b/src/router/__tests__/loaders.test.tsx
@@ -274,7 +274,7 @@ describe('Loaders', () => {
     })
 
     it('Når /vedtak/loepende-vedtak kall feiler redirigeres brukes til uventet-feil side', async () => {
-      mockErrorResponse('/v2/vedtak/loepende-vedtak')
+      mockErrorResponse('/v3/vedtak/loepende-vedtak')
 
       const mockedState = {
         userInput: { ...userInputInitialState },

--- a/src/state/api/__tests__/apiSlice-utils.test.ts
+++ b/src/state/api/__tests__/apiSlice-utils.test.ts
@@ -238,6 +238,7 @@ describe('apiSlice - utils', () => {
             alderspensjon: {
               grad: 50,
               fom: '2012-12-12',
+              sivilstand: 'UGIFT',
             },
             ufoeretrygd: {
               grad: 0,
@@ -254,6 +255,7 @@ describe('apiSlice - utils', () => {
             alderspensjon: {
               grad: 50,
               fom: '2012-12-12',
+              sivilstand: 'UGIFT',
             },
             ufoeretrygd: {
               grad: 0,
@@ -455,6 +457,7 @@ describe('apiSlice - utils', () => {
             alderspensjon: {
               grad: 50,
               fom: '2012-12-12',
+              sivilstand: 'UGIFT',
             },
             ufoeretrygd: {
               grad: 0,
@@ -470,6 +473,7 @@ describe('apiSlice - utils', () => {
             alderspensjon: {
               grad: 50,
               fom: '2012-12-12',
+              sivilstand: 'UGIFT',
             },
             ufoeretrygd: {
               grad: 0,
@@ -486,6 +490,7 @@ describe('apiSlice - utils', () => {
             alderspensjon: {
               grad: 50,
               fom: '2012-12-12',
+              sivilstand: 'UGIFT',
             },
             ufoeretrygd: {
               grad: 50,
@@ -666,7 +671,7 @@ describe('apiSlice - utils', () => {
         generateAlderspensjonRequestBody({
           ...requestBody,
           loependeVedtak: {
-            alderspensjon: { grad: 60, fom: '2010-10-10' },
+            alderspensjon: { grad: 60, fom: '2010-10-10', sivilstand: 'UGIFT' },
             ufoeretrygd: { grad: 0 },
             harFremtidigLoependeVedtak: false,
           },
@@ -677,7 +682,7 @@ describe('apiSlice - utils', () => {
           ...requestBody,
           afp: null,
           loependeVedtak: {
-            alderspensjon: { grad: 60, fom: '2010-10-10' },
+            alderspensjon: { grad: 60, fom: '2010-10-10', sivilstand: 'UGIFT' },
             ufoeretrygd: { grad: 0 },
             harFremtidigLoependeVedtak: false,
           },

--- a/src/state/api/__tests__/apiSlice.test.ts
+++ b/src/state/api/__tests__/apiSlice.test.ts
@@ -211,7 +211,7 @@ describe('apiSlice', () => {
     it('kaster feil ved uforventet format på data', async () => {
       const storeRef = setupStore(undefined, true)
 
-      mockResponse('/v2/vedtak/loepende-vedtak', {
+      mockResponse('/v3/vedtak/loepende-vedtak', {
         json: {
           feil: 'format',
         },

--- a/src/state/api/__tests__/typeguards.test.tsx
+++ b/src/state/api/__tests__/typeguards.test.tsx
@@ -798,6 +798,7 @@ describe('Typeguards', () => {
       alderspensjon: {
         grad: 0,
         fom: '2020-10-02',
+        sivilstand: 'UGIFT',
       },
       ufoeretrygd: {
         grad: 75,
@@ -861,6 +862,7 @@ describe('Typeguards', () => {
           alderspensjon: {},
         })
       ).toEqual(false)
+
       expect(
         isLoependeVedtak({
           ...correctResponse,
@@ -883,13 +885,22 @@ describe('Typeguards', () => {
       expect(
         isLoependeVedtak({
           ...correctResponse,
-          alderspensjon: { grad: '75' },
+          alderspensjon: {
+            ...correctResponse.alderspensjon,
+            sivilstand: undefined,
+          },
         })
       ).toEqual(false)
       expect(
         isLoependeVedtak({
           ...correctResponse,
-          alderspensjon: { grad: 75, fom: 123 },
+          alderspensjon: { grad: '75', sivilstand: 'UGIFT' },
+        })
+      ).toEqual(false)
+      expect(
+        isLoependeVedtak({
+          ...correctResponse,
+          alderspensjon: { grad: 75, fom: 123, sivilstand: 'UGIFT' },
         })
       ).toEqual(false)
       expect(

--- a/src/state/api/apiSlice.ts
+++ b/src/state/api/apiSlice.ts
@@ -88,7 +88,7 @@ export const apiSlice = createApi({
       },
     }),
     getLoependeVedtak: builder.query<LoependeVedtak, void>({
-      query: () => '/v2/vedtak/loepende-vedtak',
+      query: () => '/v3/vedtak/loepende-vedtak',
       transformResponse: (response) => {
         if (!isLoependeVedtak(response)) {
           throw new Error(

--- a/src/state/api/typeguards.ts
+++ b/src/state/api/typeguards.ts
@@ -279,7 +279,20 @@ export const isLoependeVedtak = (data?: any): data is LoependeVedtak => {
       (data.alderspensjon &&
         typeof data.alderspensjon === 'object' &&
         data.alderspensjon.grad !== undefined &&
-        typeof data.alderspensjon.grad === 'number')) &&
+        typeof data.alderspensjon.grad === 'number' &&
+        [
+          null,
+          'UOPPGITT',
+          'UGIFT',
+          'GIFT',
+          'ENKE_ELLER_ENKEMANN',
+          'SKILT',
+          'SEPARERT',
+          'REGISTRERT_PARTNER',
+          'SEPARERT_PARTNER',
+          'SKILT_PARTNER',
+          'GJENLEVENDE_PARTNER',
+        ].includes(data.alderspensjon.sivilstand))) &&
     (!data.alderspensjon ||
       (data.alderspensjon &&
         data.alderspensjon.fom &&

--- a/src/state/userInput/__tests__/selectors.test.ts
+++ b/src/state/userInput/__tests__/selectors.test.ts
@@ -121,13 +121,17 @@ describe('userInput selectors', () => {
   })
 
   describe('selectSivilstand', () => {
-    it('returnerer undefined sivilstand når /person har ikke blitt kalt eller har feilet', () => {
+    it('Når brukeren har vedtak om alderspensjon, returnerer sivilstand fra vedtaket.', () => {
       const state: RootState = {
         ...initialState,
+        api: {
+          // @ts-ignore
+          queries: { ...fulfilledGetLoependeVedtakLoependeAlderspensjon },
+        },
       }
-      expect(selectSivilstand(state)).toBe(undefined)
+      expect(selectSivilstand(state)).toBe('UGIFT')
     })
-    it('returnerer riktig sivilstand når queryen er vellykket', () => {
+    it('Når brukeren har vedtak om alderspensjon, returnerer sivilstand fra /person.', () => {
       const state: RootState = {
         ...initialState,
         api: {
@@ -136,6 +140,12 @@ describe('userInput selectors', () => {
         },
       }
       expect(selectSivilstand(state)).toBe('UGIFT')
+    })
+    it('Når brukeren ikke har vedtak om alderspensjon og at /person ikke er blitt kalt eller har feilet, returnerer undefined', () => {
+      const state: RootState = {
+        ...initialState,
+      }
+      expect(selectSivilstand(state)).toBe(undefined)
     })
   })
 

--- a/src/state/userInput/__tests__/selectors.test.ts
+++ b/src/state/userInput/__tests__/selectors.test.ts
@@ -122,31 +122,35 @@ describe('userInput selectors', () => {
   })
 
   describe('selectSivilstand', () => {
-    it('Når brukeren har vedtak om alderspensjon, returnerer sivilstand fra vedtaket.', () => {
-      const state: RootState = {
-        ...initialState,
-        api: {
-          // @ts-ignore
-          queries: { ...fulfilledGetLoependeVedtakLoependeAlderspensjon },
-        },
-      }
-      expect(selectSivilstand(state)).toBe('UGIFT')
+    describe('Gitt at brukeren har vedtak om alderspensjon, ', () => {
+      it('returnerer sivilstand fra vedtaket.', () => {
+        const state: RootState = {
+          ...initialState,
+          api: {
+            // @ts-ignore
+            queries: { ...fulfilledGetLoependeVedtakLoependeAlderspensjon },
+          },
+        }
+        expect(selectSivilstand(state)).toBe('UGIFT')
+      })
     })
-    it('Når brukeren har vedtak om alderspensjon, returnerer sivilstand fra /person.', () => {
-      const state: RootState = {
-        ...initialState,
-        api: {
-          // @ts-ignore
-          queries: { ...fulfilledGetPerson },
-        },
-      }
-      expect(selectSivilstand(state)).toBe('UGIFT')
-    })
-    it('Når brukeren ikke har vedtak om alderspensjon og at /person ikke er blitt kalt eller har feilet, returnerer undefined', () => {
-      const state: RootState = {
-        ...initialState,
-      }
-      expect(selectSivilstand(state)).toBe(undefined)
+    describe('Gitt at brukeren ikker har vedtak om alderspensjon, ', () => {
+      it('returnerer sivilstand fra /person.', () => {
+        const state: RootState = {
+          ...initialState,
+          api: {
+            // @ts-ignore
+            queries: { ...fulfilledGetPerson },
+          },
+        }
+        expect(selectSivilstand(state)).toBe('UGIFT')
+      })
+      it('Når /person ikke er blitt kalt eller har feilet, returnerer undefined.', () => {
+        const state: RootState = {
+          ...initialState,
+        }
+        expect(selectSivilstand(state)).toBe(undefined)
+      })
     })
   })
 

--- a/src/state/userInput/__tests__/selectors.test.ts
+++ b/src/state/userInput/__tests__/selectors.test.ts
@@ -7,6 +7,7 @@ import {
   selectSivilstand,
   selectSamboerFraBrukerInput,
   selectSamboerFraSivilstand,
+  selectSamboerFraVedtak,
   selectSamboer,
   selectAarligInntektFoerUttakBeloepFraBrukerInput,
   selectAarligInntektFoerUttakBeloepFraSkatt,
@@ -185,48 +186,139 @@ describe('userInput selectors', () => {
     })
   })
 
-  describe('selectSamboer', () => {
-    it('returnerer samboerskap basert på svaret som brukeren har oppgitt, til tross for at sivilstanden sier noe annet', () => {
+  describe('selectSamboerFraVedtak', () => {
+    it('returnerer false når sivilstanden medfører at personen ikke har samboer', () => {
       const state: RootState = {
         ...initialState,
         api: {
           // @ts-ignore
-          queries: { ...fulfilledGetPerson },
-        },
-        userInput: {
-          ...initialState.userInput,
-          samboer: true,
+          queries: { ...fulfilledGetLoependeVedtakLoependeAlderspensjon },
         },
       }
-      expect(selectSamboer(state)).toBe(true)
+      expect(selectSamboerFraVedtak(state)).toBe(false)
     })
-
-    it('returnerer samboerskap basert på sivilstand, og at brukeren ikke svarte spørsmålet om samboer', () => {
+    it('returnerer true når sivilstanden medfører at personen har samboer', () => {
       const state: RootState = {
         ...initialState,
         api: {
           queries: {
-            ['getPerson(undefined)']: {
+            ['getLoependeVedtak(undefined)']: {
               // @ts-ignore
               status: 'fulfilled',
-              endpointName: 'getPerson',
+              endpointName: 'getLoependeVedtak',
               requestId: 'xTaE6mOydr5ZI75UXq4Wi',
               startedTimeStamp: 1688046411971,
               data: {
-                navn: 'Aprikos',
-                sivilstand: 'GIFT',
-                foedselsdato: '1963-04-30',
+                alderspensjon: {
+                  grad: 100,
+                  fom: '2020-10-02',
+                  sivilstand: 'GIFT' as Sivilstand,
+                },
+                ufoeretrygd: {
+                  grad: 0,
+                },
+                harFremtidigLoependeVedtak: false,
               },
               fulfilledTimeStamp: 1688046412103,
             },
           },
         },
-        userInput: {
-          ...initialState.userInput,
-          samboer: null,
-        },
       }
-      expect(selectSamboer(state)).toBe(true)
+      expect(selectSamboerFraVedtak(state)).toBe(true)
+    })
+  })
+
+  describe('selectSamboer', () => {
+    describe('Gitt at brukeren har vedtak om alderspensjon', () => {
+      it('returnerer samboerskap basert på sivilstanden fra vedtaket', () => {
+        const stateMedVedtakMedSivilstandUgift: RootState = {
+          ...initialState,
+          api: {
+            // @ts-ignore
+            queries: { ...fulfilledGetLoependeVedtakLoependeAlderspensjon },
+          },
+          userInput: {
+            ...initialState.userInput,
+          },
+        }
+        expect(selectSamboer(stateMedVedtakMedSivilstandUgift)).toBe(false)
+
+        const stateMedVedtakMedSivilstandGift: RootState = {
+          ...initialState,
+          api: {
+            queries: {
+              ['getLoependeVedtak(undefined)']: {
+                // @ts-ignore
+                status: 'fulfilled',
+                endpointName: 'getLoependeVedtak',
+                requestId: 'xTaE6mOydr5ZI75UXq4Wi',
+                startedTimeStamp: 1688046411971,
+                data: {
+                  alderspensjon: {
+                    grad: 100,
+                    fom: '2020-10-02',
+                    sivilstand: 'GIFT' as Sivilstand,
+                  },
+                  ufoeretrygd: {
+                    grad: 0,
+                  },
+                  harFremtidigLoependeVedtak: false,
+                },
+                fulfilledTimeStamp: 1688046412103,
+              },
+            },
+          },
+          userInput: {
+            ...initialState.userInput,
+          },
+        }
+        expect(selectSamboer(stateMedVedtakMedSivilstandGift)).toBe(true)
+      })
+    })
+
+    describe('Gitt at brukeren ikke har vedtak om alderspensjon', () => {
+      it('returnerer samboerskap basert på svaret som brukeren har oppgitt, til tross for at sivilstanden fra person sier noe annet', () => {
+        const state: RootState = {
+          ...initialState,
+          api: {
+            // @ts-ignore
+            queries: { ...fulfilledGetPerson },
+          },
+          userInput: {
+            ...initialState.userInput,
+            samboer: true,
+          },
+        }
+        expect(selectSamboer(state)).toBe(true)
+      })
+
+      it('returnerer samboerskap basert på sivilstand, og at brukeren ikke svarte spørsmålet om samboer', () => {
+        const state: RootState = {
+          ...initialState,
+          api: {
+            queries: {
+              ['getPerson(undefined)']: {
+                // @ts-ignore
+                status: 'fulfilled',
+                endpointName: 'getPerson',
+                requestId: 'xTaE6mOydr5ZI75UXq4Wi',
+                startedTimeStamp: 1688046411971,
+                data: {
+                  navn: 'Aprikos',
+                  sivilstand: 'GIFT',
+                  foedselsdato: '1963-04-30',
+                },
+                fulfilledTimeStamp: 1688046412103,
+              },
+            },
+          },
+          userInput: {
+            ...initialState.userInput,
+            samboer: null,
+          },
+        }
+        expect(selectSamboer(state)).toBe(true)
+      })
     })
   })
 

--- a/src/state/userInput/selectors.ts
+++ b/src/state/userInput/selectors.ts
@@ -40,7 +40,6 @@ export const selectFoedselsdato = createSelector(
 export const selectSamboerFraBrukerInput = (state: RootState): boolean | null =>
   state.userInput.samboer
 
-// TODO skrive tester
 export const selectSivilstand = createSelector(
   [(state) => state, (_, params = undefined) => params],
   (state) => {

--- a/src/state/userInput/selectors.ts
+++ b/src/state/userInput/selectors.ts
@@ -40,11 +40,15 @@ export const selectFoedselsdato = createSelector(
 export const selectSamboerFraBrukerInput = (state: RootState): boolean | null =>
   state.userInput.samboer
 
+// TODO skrive tester
 export const selectSivilstand = createSelector(
   [(state) => state, (_, params = undefined) => params],
   (state) => {
-    return apiSlice.endpoints.getPerson.select(undefined)(state)?.data
-      ?.sivilstand
+    const isEndring = selectIsEndring(state)
+    return isEndring
+      ? apiSlice.endpoints.getLoependeVedtak.select(undefined)(state)?.data
+          ?.alderspensjon?.sivilstand
+      : apiSlice.endpoints.getPerson.select(undefined)(state)?.data?.sivilstand
   }
 )
 
@@ -57,10 +61,26 @@ export const selectSamboerFraSivilstand = createSelector(
   }
 )
 
+// TODO avklare hvor de verdiene for epsHarPensjon og epsHarInntektOver2G skal komme fra for brukere som beregner Endring
+// TODO skriver ikke tester - skal fases ut til fordel for selectEpsHarInntektOver2G og selectEpsHarPensjon
+export const selectSamboerFraVedtak = createSelector(
+  [(state) => state, (_, params = undefined) => params],
+  (state) => {
+    const sivilstand =
+      apiSlice.endpoints.getLoependeVedtak.select(undefined)(state)?.data
+        ?.alderspensjon?.sivilstand
+    return sivilstand ? checkHarSamboer(sivilstand) : null
+  }
+)
+
+// TODO skriver ikke tester - skal fases ut til fordel for selectEpsHarInntektOver2G og selectEpsHarPensjon
 export const selectSamboer = (state: RootState): boolean | null => {
+  const isEndring = selectIsEndring(state)
   const samboerskapFraBrukerInput = selectSamboerFraBrukerInput(state)
   if (samboerskapFraBrukerInput === null) {
-    return selectSamboerFraSivilstand(state, undefined)
+    return isEndring
+      ? selectSamboerFraVedtak(state, undefined)
+      : selectSamboerFraSivilstand(state, undefined)
   }
   return samboerskapFraBrukerInput
 }

--- a/src/state/userInput/selectors.ts
+++ b/src/state/userInput/selectors.ts
@@ -60,8 +60,6 @@ export const selectSamboerFraSivilstand = createSelector(
   }
 )
 
-// TODO avklare hvor de verdiene for epsHarPensjon og epsHarInntektOver2G skal komme fra for brukere som beregner Endring
-// TODO skriver ikke tester - skal fases ut til fordel for selectEpsHarInntektOver2G og selectEpsHarPensjon
 export const selectSamboerFraVedtak = createSelector(
   [(state) => state, (_, params = undefined) => params],
   (state) => {
@@ -72,7 +70,6 @@ export const selectSamboerFraVedtak = createSelector(
   }
 )
 
-// TODO skriver ikke tester - skal fases ut til fordel for selectEpsHarInntektOver2G og selectEpsHarPensjon
 export const selectSamboer = (state: RootState): boolean | null => {
   const isEndring = selectIsEndring(state)
   const samboerskapFraBrukerInput = selectSamboerFraBrukerInput(state)

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -204,6 +204,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/api/v3/vedtak/loepende-vedtak': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Har løpende vedtak
+     * @description Hvorvidt den innloggede brukeren har løpende uføretrygd med uttaksgrad, alderspensjon med uttaksgrad, AFP i privat eller offentlig sektor
+     */
+    get: operations['hentLoependeVedtakV3']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/api/v2/vedtak/loepende-vedtak': {
     parameters: {
       query?: never
@@ -1089,6 +1109,46 @@ export interface components {
         | 'GJENLEVENDE_PARTNER'
       pensjoneringAldre: components['schemas']['PersonPensjoneringAldreV4']
     }
+    AlderspensjonDetaljerV3: {
+      /** Format: int32 */
+      grad: number
+      /** Format: date */
+      fom: string
+      sisteUtbetaling?: components['schemas']['UtbetalingV3']
+      /** @enum {string} */
+      sivilstand:
+        | 'UNKNOWN'
+        | 'UOPPGITT'
+        | 'UGIFT'
+        | 'GIFT'
+        | 'ENKE_ELLER_ENKEMANN'
+        | 'SKILT'
+        | 'SEPARERT'
+        | 'REGISTRERT_PARTNER'
+        | 'SEPARERT_PARTNER'
+        | 'SKILT_PARTNER'
+        | 'GJENLEVENDE_PARTNER'
+    }
+    LoependeFraV3: {
+      /** Format: date */
+      fom: string
+    }
+    LoependeVedtakV3: {
+      alderspensjon?: components['schemas']['AlderspensjonDetaljerV3']
+      harFremtidigLoependeVedtak: boolean
+      ufoeretrygd: components['schemas']['UfoeretrygdDetaljerV3']
+      afpPrivat?: components['schemas']['LoependeFraV3']
+      afpOffentlig?: components['schemas']['LoependeFraV3']
+    }
+    UfoeretrygdDetaljerV3: {
+      /** Format: int32 */
+      grad: number
+    }
+    UtbetalingV3: {
+      beloep: number
+      /** Format: date */
+      utbetalingsdato: string
+    }
     AlderspensjonDetaljerV2: {
       /** Format: int32 */
       grad: number
@@ -1515,6 +1575,35 @@ export interface operations {
         }
       }
       /** @description Henting av personinformasjon kunne ikke utføres av tekniske årsaker. */
+      503: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': unknown
+        }
+      }
+    }
+  }
+  hentLoependeVedtakV3: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Henting av løpende vedtak utført */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['LoependeVedtakV3']
+        }
+      }
+      /** @description Henting av løpende vedtak kunne ikke utføres av tekniske årsaker */
       503: {
         headers: {
           [name: string]: unknown

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -37,6 +37,7 @@ declare global {
   >
   type Person = components['schemas']['PersonResultV4']
   type Sivilstand = components['schemas']['PersonResultV4']['sivilstand']
+
   type UtvidetSivilstand = Sivilstand | 'SAMBOER'
   type pensjoneringAldre =
     components['schemas']['PersonResultV4']['pensjoneringAldre']
@@ -61,13 +62,13 @@ declare global {
   type OmstillingsstoenadOgGjenlevende =
     components['schemas']['BrukerHarLoependeOmstillingsstoenadEllerGjenlevendeYtelse']
 
-  // /v2/vedtak/loepende-vedtak
+  // /v3/vedtak/loepende-vedtak
   export type GetLoependeVedtakQuery = TypedUseQueryStateResult<
     LoependeVedtak,
     void,
     BaseQueryFn<Record<string, unknown>, LoependeVedtak>
   >
-  type LoependeVedtak = components['schemas']['LoependeVedtakV2']
+  type LoependeVedtak = components['schemas']['LoependeVedtakV3']
 
   // /tidligste-uttaksalder
   type TidligstMuligHeltUttakRequestBody =


### PR DESCRIPTION
- tar i bruk v3 av vedtak/loepende-vedtak
- utvider selectors til å hente sivilstand fra vedtak for endring.
- bruker riktig sivilstand til de ulike API-payload: tmu, alderspensjon, pensjonsavtaler, offentlig-tp
- bruker riktig sivilstand til Grunnlag
