### PR TITLE
Justering av lint-staged scripts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,13 +6,14 @@ import globals from 'globals'
 
 const ignoredFiles = [
   'eslint.config.mjs',
-  'dist/*',
+  'dist/**',
+  'dist-sanity/**',
   '.nginx/*',
   '.nais/*',
   'src/nais.js',
   '**/api',
   '**/coverage',
-  '**/vite.config.ts',
+  '**/vite.config.ts*',
   '**/.stylelintrc.cjs',
   '**/tsconfig.json',
   '**/tsconfig.node.json',

--- a/package.json
+++ b/package.json
@@ -113,11 +113,11 @@
   },
   "lint-staged": {
     "**/*.{css,scss}": [
-      "npm run stylelint:check"
+      "stylelint"
     ],
     "**/*.{cjs,js,jsx,ts,tsx}": [
-      "npm run prettier:check",
-      "npm run eslint:check"
+      "prettier",
+      "eslint"
     ]
   }
 }


### PR DESCRIPTION
lint-staged legger dynamisk til i kommandoen hver enkelt fil som er endret. Dette har imidlertid ingen effekt i dag. Denne endringen gjør at bare endrede filer blir kjørt igjennom stylelint, prettier og eslint, slik at det tar kortere tid.