### PR TITLE
Bruk ErrorMessage i stedet for custom CSS i AgePicker

### DIFF
--- a/src/components/common/AgePicker/AgePicker.module.scss
+++ b/src/components/common/AgePicker/AgePicker.module.scss
@@ -49,19 +49,7 @@
 
   &Error {
     &Message {
-      display: flex;
-      gap: var(--a-spacing-2);
-      color: var(--a-text-danger);
-      font-size: var(--a-font-size-large);
-      font-weight: var(--a-font-weight-bold);
-      letter-spacing: 0;
-      line-height: var(--a-font-line-height-large);
-      margin: 0;
       padding-top: var(--a-spacing-2);
-
-      &::before {
-        content: '•';
-      }
 
       :global {
         .nowrap {

--- a/src/components/common/AgePicker/AgePicker.tsx
+++ b/src/components/common/AgePicker/AgePicker.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react'
 import { useIntl } from 'react-intl'
 
-import { BodyShort, Label, Select } from '@navikt/ds-react'
+import { BodyShort, ErrorMessage, Label, Select } from '@navikt/ds-react'
 import clsx from 'clsx'
 
 import { Alert as AlertDashBorder } from '@/components/common/Alert'
@@ -244,7 +244,9 @@ export const AgePicker = forwardRef<HTMLDivElement, AgePickerProps>(
             aria-relevant="additions removals"
             aria-live="polite"
           >
-            <p className={styles.selectErrorMessage}>{error}</p>
+            <ErrorMessage showIcon className={styles.selectErrorMessage}>
+              {error}
+            </ErrorMessage>
           </div>
         )}
         {info && <AlertDashBorder>{info}</AlertDashBorder>}


### PR DESCRIPTION
Dette sørger for at feilmeldingene ser likt ut som i skjemakomponentene fra Aksel.