### PR TITLE
Fjern `selected` på `<option>`

### DIFF
--- a/src/components/RedigerAvansertBeregning/RedigerAvansertBeregning.tsx
+++ b/src/components/RedigerAvansertBeregning/RedigerAvansertBeregning.tsx
@@ -536,7 +536,7 @@ export const RedigerAvansertBeregning: React.FC<{
             }
             aria-required="true"
           >
-            <option disabled selected value="">
+            <option disabled value="">
               {' '}
             </option>
             {muligeUttaksgrad.map((grad) => (

--- a/src/components/UtenlandsoppholdModal/UtenlandsoppholdModal.tsx
+++ b/src/components/UtenlandsoppholdModal/UtenlandsoppholdModal.tsx
@@ -148,7 +148,7 @@ export const UtenlandsoppholdModal: React.FC<Props> = ({
               }
               aria-required="true"
             >
-              <option disabled selected value="">
+              <option disabled value="">
                 {' '}
               </option>
               {landListeData.map((land) => (

--- a/src/components/common/AgePicker/AgePicker.tsx
+++ b/src/components/common/AgePicker/AgePicker.tsx
@@ -160,7 +160,7 @@ export const AgePicker = forwardRef<HTMLDivElement, AgePickerProps>(
             aria-invalid={hasError.aar}
             aria-required
           >
-            <option disabled selected value="">
+            <option disabled value="">
               {' '}
             </option>
             {yearsArray.map((year) => {
@@ -199,7 +199,7 @@ export const AgePicker = forwardRef<HTMLDivElement, AgePickerProps>(
             aria-invalid={hasError.maaneder}
             aria-required
           >
-            <option disabled selected value="">
+            <option disabled value="">
               {' '}
             </option>
             {monthsArray.map((month) => {


### PR DESCRIPTION
Bruk av `selected` på `<option>` gir følgende feilmelding i nettleser-konsollen:
```
Use the `defaultValue` or `value` props on <select> instead of setting `selected` on <option>.
```