### PR TITLE
Flyttet sanityClient for å redusere byggstørrelsen

### DIFF
--- a/sanity.cli.ts
+++ b/sanity.cli.ts
@@ -1,8 +1,9 @@
 import { defineCliConfig } from 'sanity/cli'
+import { projectId } from './sanity.config'
 
 export default defineCliConfig({
   api: {
-    projectId: 'g2by7q6m',
+    projectId,
     dataset: 'development',
   },
   /**

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,4 +1,3 @@
-import { createClient, type ClientConfig } from '@sanity/client'
 import { documentInternationalization } from '@sanity/document-internationalization'
 import { RobotIcon, RocketIcon } from '@sanity/icons'
 import { visionTool } from '@sanity/vision'
@@ -9,21 +8,6 @@ import { schemaTypes } from './schemaTypes'
 import { supportedLanguages } from './schemaTypes/supportedLanguages'
 
 export const projectId = 'g2by7q6m'
-const dataset =
-  window.location.href.includes('ekstern.dev') ||
-  window.location.href.includes('localhost')
-    ? 'development'
-    : 'production'
-
-const config: ClientConfig = {
-  projectId,
-  dataset,
-
-  useCdn: true, // set to `false` to bypass the edge cache
-  apiVersion: '2023-05-03', // use current date (YYYY-MM-DD) to target the latest API version
-}
-
-export const sanityClient = createClient(config)
 
 const pluginsArray = [
   structureTool(),

--- a/src/context/LanguageProvider/LanguageProvider.tsx
+++ b/src/context/LanguageProvider/LanguageProvider.tsx
@@ -8,7 +8,6 @@ import {
   onLanguageSelect,
 } from '@navikt/nav-dekoratoren-moduler'
 
-import { sanityClient } from '../../../sanity.config'
 import { SanityContext } from '@/context/SanityContext'
 import {
   SanityForbeholdAvsnitt,
@@ -16,6 +15,7 @@ import {
 } from '@/context/SanityContext/SanityTypes'
 import { useGetSpraakvelgerFeatureToggleQuery } from '@/state/api/apiSlice'
 import { logger } from '@/utils/logging'
+import { sanityClient } from '@/utils/sanity'
 import '@formatjs/intl-numberformat/polyfill-force'
 import '@formatjs/intl-numberformat/locale-data/en'
 import '@formatjs/intl-numberformat/locale-data/nb'

--- a/src/context/LanguageProvider/__tests__/LanguageProvider.test.tsx
+++ b/src/context/LanguageProvider/__tests__/LanguageProvider.test.tsx
@@ -4,11 +4,11 @@ import { Provider } from 'react-redux'
 
 import { render, screen, waitFor } from '@testing-library/react'
 
-import { sanityClient } from '../../../../sanity.config'
 import { setupStore } from '../../../state/store'
 import { LanguageProvider } from '../LanguageProvider'
 import { SanityContext } from '@/context/SanityContext'
 import { mockErrorResponse } from '@/mocks/server'
+import { sanityClient } from '@/utils/sanity'
 
 function TestComponent() {
   const intl = useIntl()

--- a/src/state/api/__tests__/apiSlice.test.ts
+++ b/src/state/api/__tests__/apiSlice.test.ts
@@ -1,5 +1,3 @@
-import { FetchBaseQueryError } from '@reduxjs/toolkit/query/react'
-
 import alderspensjonResponse from '../../../mocks/data/alderspensjon/67.json' with { type: 'json' }
 import ekskludertStatusResponse from '../../../mocks/data/ekskludert-status.json' with { type: 'json' }
 import inntektResponse from '../../../mocks/data/inntekt.json' with { type: 'json' }

--- a/src/utils/sanity.tsx
+++ b/src/utils/sanity.tsx
@@ -3,8 +3,22 @@ import { IntlShape } from 'react-intl'
 import { ExternalLinkIcon } from '@navikt/aksel-icons'
 import { Link } from '@navikt/ds-react'
 import { PortableTextReactComponents } from '@portabletext/react'
+import { createClient } from '@sanity/client'
 
 import { logOpenLink } from './logging'
+
+const dataset =
+  window.location.href.includes('ekstern.dev') ||
+  window.location.href.includes('localhost')
+    ? 'development'
+    : 'production'
+
+export const sanityClient = createClient({
+  projectId: 'g2by7q6m',
+  dataset,
+  useCdn: true, // set to `false` to bypass the edge cache
+  apiVersion: '2023-05-03', // use current date (YYYY-MM-DD) to target the latest API version
+})
 
 export const getSanityPortableTextComponents = (
   intl: IntlShape


### PR DESCRIPTION
Før:
```
Export "structureLocaleNamespace" of module "node_modules/sanity/lib/_chunks-es/pane.mjs" was reexported through module "node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/sanity/lib/_chunks-es/pane.mjs" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
Export "useDocumentPane" of module "node_modules/sanity/lib/_chunks-es/pane.mjs" was reexported through module "node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/sanity/lib/_chunks-es/pane.mjs" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
Export "usePaneRouter" of module "node_modules/sanity/lib/_chunks-es/pane.mjs" was reexported through module "node_modules/sanity/lib/structure.mjs" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "node_modules/sanity/lib/_chunks-es/pane.mjs" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.
dist/veileder/index.html                          1.45 kB │ gzip:     0.54 kB
dist/index.html                                   2.01 kB │ gzip:     0.74 kB
dist/assets/appVeileder-azDRxjRj.css              0.13 kB │ gzip:     0.13 kB
dist/assets/designsystem-CKfBNJpN.css           255.49 kB │ gzip:    35.69 kB
dist/assets/resources-BmsyfWob.js                 0.38 kB │ gzip:     0.21 kB │ map:      0.72 kB
dist/assets/appBorger-Dr4VRFTI.js                 0.69 kB │ gzip:     0.45 kB │ map:      2.17 kB
dist/assets/refractor-C2d9CP_U.js                 0.84 kB │ gzip:     0.54 kB │ map:      2.66 kB
dist/assets/ViteDevServerStopped-wTHn_RNN.js      1.42 kB │ gzip:     0.77 kB │ map:      4.28 kB
dist/assets/resources-8GGBtkAp.js                 1.57 kB │ gzip:     0.71 kB │ map:      4.63 kB
dist/assets/resources4-BZNO8Lal.js                2.35 kB │ gzip:     0.98 kB │ map:      4.71 kB
dist/assets/index-DpwHU5gE.js                     2.41 kB │ gzip:     1.26 kB │ map:      9.31 kB
dist/assets/index2-C1t9omVh.js                    3.52 kB │ gzip:     1.78 kB │ map:     12.25 kB
dist/assets/resources-CINxi45p.js                 4.49 kB │ gzip:     1.44 kB │ map:     13.34 kB
dist/assets/resources3-M_dJ2OZk.js                4.56 kB │ gzip:     1.36 kB │ map:     12.18 kB
dist/assets/appVeileder-DohHrn1u.js               4.98 kB │ gzip:     2.14 kB │ map:     18.19 kB
dist/assets/stegaEncodeSourceMap-CL80a-8v.js      7.66 kB │ gzip:     3.17 kB │ map:     24.57 kB
dist/assets/resources2-BLRUDDrt.js                9.50 kB │ gzip:     2.19 kB │ map:     22.58 kB
dist/assets/browser-D6oVUnCt.js                  12.69 kB │ gzip:     5.05 kB │ map:     55.72 kB
dist/assets/resources5-DREEUasV.js               17.41 kB │ gzip:     4.25 kB │ map:     40.11 kB
dist/assets/index3-CxsKkLYC.js                   24.47 kB │ gzip:     9.69 kB │ map:     92.33 kB
dist/assets/faro-C0pkA4PS.js                     80.06 kB │ gzip:    27.25 kB │ map:    315.75 kB
dist/assets/react-redux-ar3axock.js             121.74 kB │ gzip:    42.19 kB │ map:    751.11 kB
dist/assets/intl-DCHLsYPw.js                    247.43 kB │ gzip:    81.01 kB │ map:  1,165.91 kB
dist/assets/designsystem-iznZeY3J.js            254.94 kB │ gzip:    65.02 kB │ map:  1,316.20 kB
dist/assets/highcharts-DTWu-Okb.js              279.17 kB │ gzip:   103.58 kB │ map:    640.17 kB
dist/assets/SanityVision-C6ZJCgPf.js            574.71 kB │ gzip:   190.79 kB │ map:  2,223.83 kB
dist/assets/designsystem-BInxHVVN.js          5,489.11 kB │ gzip: 1,598.77 kB │ map: 19,669.79 kB
```

Etter:
```
dist/veileder/index.html                          1.45 kB │ gzip:   0.54 kB
dist/index.html                                   2.01 kB │ gzip:   0.74 kB
dist/assets/appVeileder-azDRxjRj.css              0.13 kB │ gzip:   0.13 kB
dist/assets/designsystem-CKfBNJpN.css           255.49 kB │ gzip:  35.69 kB
dist/assets/appBorger-0rSTz7al.js                 0.69 kB │ gzip:   0.45 kB │ map:     2.17 kB
dist/assets/appVeileder-DXfYZKwO.js               4.98 kB │ gzip:   2.15 kB │ map:    18.19 kB
dist/assets/stegaEncodeSourceMap-DFv_Ib07.js      7.66 kB │ gzip:   3.18 kB │ map:    24.57 kB
dist/assets/browser-CUK-VHA5.js                  12.69 kB │ gzip:   5.05 kB │ map:    55.72 kB
dist/assets/faro-C0pkA4PS.js                     80.06 kB │ gzip:  27.25 kB │ map:   315.75 kB
dist/assets/react-redux-D6BfetBX.js             121.71 kB │ gzip:  42.17 kB │ map:   751.07 kB
dist/assets/intl-BQisQhWQ.js                    247.43 kB │ gzip:  81.01 kB │ map: 1,165.91 kB
dist/assets/designsystem-zVPeAmI4.js            254.19 kB │ gzip:  64.79 kB │ map: 1,315.04 kB
dist/assets/highcharts-DVYg6JWJ.js              279.04 kB │ gzip: 103.55 kB │ map:   640.17 kB
dist/assets/designsystem-D6kfcScj.js          1,030.58 kB │ gzip: 256.47 kB │ map: 3,344.45 kB
```