### PR TITLE
Fjernet ubrukt pakke react-router-dom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
         "react-intl": "7.1.6",
         "react-redux": "^9.2.0",
         "react-router": "^7.1.5",
-        "react-router-dom": "^7.1.5",
         "rollup-plugin-visualizer": "^5.14.0",
         "sass": "^1.83.4",
         "start-server-and-test": "^2.0.10",
@@ -19002,23 +19001,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.1.5.tgz",
-      "integrity": "sha512-/4f9+up0Qv92D3bB8iN5P1s3oHAepSGa9h5k6tpTFlixTTskJZwKGhJ6vRJ277tLD1zuaZTt95hyGWV1Z37csQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.1.5"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-router/node_modules/cookie": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "react-intl": "7.1.6",
     "react-redux": "^9.2.0",
     "react-router": "^7.1.5",
-    "react-router-dom": "^7.1.5",
     "rollup-plugin-visualizer": "^5.14.0",
     "sass": "^1.83.4",
     "start-server-and-test": "^2.0.10",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
             'redux',
             'redux-thunk',
             '@reduxjs/toolkit',
-            'react-router-dom',
+            'react-router',
           ],
           ['designsystem']: ['@navikt/ds-react'],
           ['faro']: ['@grafana/faro-web-sdk'],


### PR DESCRIPTION
[Trengs ikke lenger i v7](https://reactrouter.com/upgrading/v6#upgrade-to-v7:~:text=In%20v7%20we%20no%20longer%20need%20%22react%2Drouter%2Ddom%22%20as%20the%20packages%20have%20been%20simplified)