### PR TITLE
Fiks test av isFoedselsdatoOverAlder

### DIFF
--- a/src/utils/__tests__/alder.test.ts
+++ b/src/utils/__tests__/alder.test.ts
@@ -220,6 +220,7 @@ describe('alder-utils', () => {
     })
 
     it('returnerer false når fødselsdatoen gir samme antall aar og måneder, og flere dager', () => {
+      vi.useFakeTimers().setSystemTime(new Date('2025-02-15'))
       const minAlderYearsBeforeNow = add(endOfDay(new Date()), {
         years: -62,
         days: -5,


### PR DESCRIPTION
Denne testen: `src/utils/__tests__/alder.test.ts > alder-utils > isFoedselsdatoOverAlder > returnerer false når fødselsdatoen gir samme antall aar og måneder, og flere dager` feiler når dagens dato er mellom den 1. og 5. i måneden. Denne endringen bør fikse det.