### PR TITLE
PEK-1047: Vis nullverdier for bare AFP i tabell og graf

### DIFF
--- a/src/components/Simulering/utils-highcharts.ts
+++ b/src/components/Simulering/utils-highcharts.ts
@@ -163,8 +163,15 @@ export function tooltipFormatter(
   const inntektSerieName = intl.formatMessage({
     id: SERIES_DEFAULT.SERIE_INNTEKT.name,
   })
+
+  const afpSerieName = intl.formatMessage({
+    id: SERIES_DEFAULT.SERIE_AFP.name,
+  })
   points.forEach(function (localPoint) {
-    if (localPoint.y && localPoint.y > 0) {
+    if (
+      (localPoint.y && localPoint.y > 0) ||
+      localPoint.series.name === afpSerieName // Unntak for AFP, skal vises hvis det er 0 i legend
+    ) {
       if (localPoint.series.name === inntektSerieName) {
         hasInntekt = true
       } else {

--- a/src/components/TabellVisning/TabellVisning.tsx
+++ b/src/components/TabellVisning/TabellVisning.tsx
@@ -172,9 +172,15 @@ export function TabellVisning({ series, aarArray }: Props) {
                 >
                   {sum > 0 ? `${formatInntekt(sum)} kr` : ''}
                 </Table.DataCell>
-                {detaljer.map(({ subSum }, j) => (
+                {detaljer.map(({ subSum, name }, j) => (
                   <Table.DataCell key={j} className={styles.detailsItemRight}>
-                    {subSum > 0 ? `${formatInntekt(subSum)} kr` : ''}
+                    {subSum > 0 ||
+                    name ===
+                      intl.formatMessage({
+                        id: SERIES_DEFAULT.SERIE_AFP.name,
+                      }) // Skal vise 0 kr, BARE hvis det er AFP som har 0 kr., ikke for andre felter med 0 kr.
+                      ? `${formatInntekt(subSum)} kr`
+                      : ''}
                   </Table.DataCell>
                 ))}
               </Table.Row>


### PR DESCRIPTION
Skal vise null-verdier for AFP i tabell og graf
![image](https://github.com/user-attachments/assets/b30dc35d-2510-4d21-9f91-5972901af2fa)
