### PR TITLE
Tesksjustering i Avansert skjema

### DIFF
--- a/cypress/e2e/pensjon/kalkulator/a11y.cy.ts
+++ b/cypress/e2e/pensjon/kalkulator/a11y.cy.ts
@@ -87,7 +87,7 @@ describe('Pensjonskalkulator', () => {
       cy.contains('Avansert').click()
     })
     cy.injectAxe()
-    cy.contains('Pensjonsgivende inntekt frem til pensjon').should('exist')
+    cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
 
     cy.checkA11y('main')
 
@@ -149,7 +149,7 @@ describe('Pensjonskalkulator', () => {
     cy.contains('Beregn pensjon').click()
 
     cy.contains('Beregning').should('not.exist')
-    cy.contains('Pensjonsgivende inntekt frem til pensjon').should('exist')
+    cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
     cy.contains(
       'Opptjeningen din er ikke høy nok til ønsket uttak. Du må øke alderen eller sette ned uttaksgraden.'
     ).should('exist')

--- a/cypress/e2e/pensjon/kalkulator/avansert.cy.ts
+++ b/cypress/e2e/pensjon/kalkulator/avansert.cy.ts
@@ -11,26 +11,34 @@ describe('Avansert', () => {
         cy.get('[data-testid="toggle-avansert"]').within(() => {
           cy.contains('Avansert').click()
         })
-        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
+        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should(
+          'exist'
+        )
       })
 
       it('forventer også å kunne gå til Avansert fra «Uttaksgrad» og «Inntekt frem til uttak» i Grunnlaget.', () => {
         cy.contains('button', '70').click()
         cy.contains('Uttaksgrad:').click({ force: true })
         cy.contains('Gå til avansert kalkulator').click({ force: true })
-        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
+        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should(
+          'exist'
+        )
         cy.contains('Enkel').click()
         cy.contains('button', '70').click()
         cy.contains('Inntekt frem til uttak:').click({ force: true })
         cy.contains('Gå til avansert kalkulator').click({ force: true })
-        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
+        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should(
+          'exist'
+        )
       })
 
       it('ønsker jeg å kunne starte ny beregning.', () => {
         cy.get('[data-testid="toggle-avansert"]').within(() => {
           cy.contains('Avansert').click()
         })
-        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
+        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should(
+          'exist'
+        )
         cy.contains('button', 'Tilbake til start').click({ force: true })
         cy.contains('button', 'Gå tilbake til start').click({ force: true })
         cy.location('href').should('include', '/pensjon/kalkulator/start')
@@ -50,7 +58,9 @@ describe('Avansert', () => {
       })
 
       it('forventer jeg å se, og kunne endre inntekt frem til pensjon.', () => {
-        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
+        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should(
+          'exist'
+        )
         cy.contains('521 338 kr per år før skatt').should('exist')
         cy.contains('button', 'Endre inntekt').click()
         cy.get('[data-testid="inntekt-textfield"]').type('0')
@@ -394,7 +404,9 @@ describe('Avansert', () => {
         cy.contains('Beregn pensjon').click()
 
         cy.contains('Beregning').should('not.exist')
-        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
+        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should(
+          'exist'
+        )
         cy.contains(
           'Opptjeningen din er ikke høy nok til ønsket uttak. Du må øke alderen eller sette ned uttaksgraden.'
         ).should('exist')
@@ -499,7 +511,9 @@ describe('Avansert', () => {
 
       it('forventer jeg å kunne endre på inntekt, pensjonsalder og uttaksgrad, og å kunne beregne pensjon.', () => {
         cy.contains('Beregning').should('not.exist')
-        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
+        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should(
+          'exist'
+        )
         cy.contains('button', 'Endre inntekt').should('exist')
         cy.contains('Når vil du ta ut alderspensjon?').should('exist')
 

--- a/cypress/e2e/pensjon/kalkulator/avansert.cy.ts
+++ b/cypress/e2e/pensjon/kalkulator/avansert.cy.ts
@@ -11,26 +11,26 @@ describe('Avansert', () => {
         cy.get('[data-testid="toggle-avansert"]').within(() => {
           cy.contains('Avansert').click()
         })
-        cy.contains('Pensjonsgivende inntekt frem til pensjon').should('exist')
+        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
       })
 
       it('forventer også å kunne gå til Avansert fra «Uttaksgrad» og «Inntekt frem til uttak» i Grunnlaget.', () => {
         cy.contains('button', '70').click()
         cy.contains('Uttaksgrad:').click({ force: true })
         cy.contains('Gå til avansert kalkulator').click({ force: true })
-        cy.contains('Pensjonsgivende inntekt frem til pensjon').should('exist')
+        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
         cy.contains('Enkel').click()
         cy.contains('button', '70').click()
         cy.contains('Inntekt frem til uttak:').click({ force: true })
         cy.contains('Gå til avansert kalkulator').click({ force: true })
-        cy.contains('Pensjonsgivende inntekt frem til pensjon').should('exist')
+        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
       })
 
       it('ønsker jeg å kunne starte ny beregning.', () => {
         cy.get('[data-testid="toggle-avansert"]').within(() => {
           cy.contains('Avansert').click()
         })
-        cy.contains('Pensjonsgivende inntekt frem til pensjon').should('exist')
+        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
         cy.contains('button', 'Tilbake til start').click({ force: true })
         cy.contains('button', 'Gå tilbake til start').click({ force: true })
         cy.location('href').should('include', '/pensjon/kalkulator/start')
@@ -50,7 +50,7 @@ describe('Avansert', () => {
       })
 
       it('forventer jeg å se, og kunne endre inntekt frem til pensjon.', () => {
-        cy.contains('Pensjonsgivende inntekt frem til pensjon').should('exist')
+        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
         cy.contains('521 338 kr per år før skatt').should('exist')
         cy.contains('button', 'Endre inntekt').click()
         cy.get('[data-testid="inntekt-textfield"]').type('0')
@@ -394,7 +394,7 @@ describe('Avansert', () => {
         cy.contains('Beregn pensjon').click()
 
         cy.contains('Beregning').should('not.exist')
-        cy.contains('Pensjonsgivende inntekt frem til pensjon').should('exist')
+        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
         cy.contains(
           'Opptjeningen din er ikke høy nok til ønsket uttak. Du må øke alderen eller sette ned uttaksgraden.'
         ).should('exist')
@@ -499,7 +499,7 @@ describe('Avansert', () => {
 
       it('forventer jeg å kunne endre på inntekt, pensjonsalder og uttaksgrad, og å kunne beregne pensjon.', () => {
         cy.contains('Beregning').should('not.exist')
-        cy.contains('Pensjonsgivende inntekt frem til pensjon').should('exist')
+        cy.contains('Pensjonsgivende årsinntekt frem til pensjon').should('exist')
         cy.contains('button', 'Endre inntekt').should('exist')
         cy.contains('Når vil du ta ut alderspensjon?').should('exist')
 

--- a/cypress/e2e/pensjon/kalkulator/endring.cy.ts
+++ b/cypress/e2e/pensjon/kalkulator/endring.cy.ts
@@ -218,7 +218,7 @@ describe('Endring av alderspensjon', () => {
           })
 
           it('forventer jeg å kunne endre inntekt frem til endring.', () => {
-            cy.contains('Pensjonsgivende inntekt frem til endring')
+            cy.contains('Pensjonsgivende årsinntekt frem til endring')
             cy.contains('button', 'Endre inntekt').click()
             cy.get('[data-testid="inntekt-textfield"]').clear().type('550000')
             cy.contains('button', 'Oppdater inntekt').click()
@@ -543,7 +543,7 @@ describe('Endring av alderspensjon', () => {
         })
 
         it('forventer jeg å kunne endre inntekt frem til endring.', () => {
-          cy.contains('Pensjonsgivende inntekt frem til endring')
+          cy.contains('Pensjonsgivende årsinntekt frem til endring')
           cy.contains('button', 'Endre inntekt').click()
           cy.get('[data-testid="inntekt-textfield"]').clear().type('550000')
           cy.contains('button', 'Oppdater inntekt').click()
@@ -869,7 +869,7 @@ describe('Endring av alderspensjon', () => {
         })
 
         it('forventer jeg å kunne endre inntekt frem til endring.', () => {
-          cy.contains('Pensjonsgivende inntekt frem til endring')
+          cy.contains('Pensjonsgivende årsinntekt frem til endring')
           cy.contains('button', 'Endre inntekt').click()
           cy.get('[data-testid="inntekt-textfield"]').clear().type('550000')
           cy.contains('button', 'Oppdater inntekt').click()
@@ -1194,7 +1194,7 @@ describe('Endring av alderspensjon', () => {
         })
 
         it('forventer jeg å kunne endre inntekt frem til endring.', () => {
-          cy.contains('Pensjonsgivende inntekt frem til endring')
+          cy.contains('Pensjonsgivende årsinntekt frem til endring')
           cy.contains('button', 'Endre inntekt').click()
           cy.get('[data-testid="inntekt-textfield"]').clear().type('550000')
           cy.contains('button', 'Oppdater inntekt').click()
@@ -1490,7 +1490,7 @@ describe('Endring av alderspensjon', () => {
         })
 
         it('forventer jeg å kunne endre inntekt frem til endring.', () => {
-          cy.contains('Pensjonsgivende inntekt frem til endring')
+          cy.contains('Pensjonsgivende årsinntekt frem til endring')
           cy.contains('button', 'Endre inntekt').click()
           cy.get('[data-testid="inntekt-textfield"]').clear().type('550000')
           cy.contains('button', 'Oppdater inntekt').click()

--- a/src/translations/nb.ts
+++ b/src/translations/nb.ts
@@ -430,9 +430,9 @@ const translations = {
   'beregning.avansert.resultatkort.inntekt_2': ' kr før skatt',
   'beregning.avansert.resultatkort.alderspensjon': 'Alderspensjon: ',
   'beregning.avansert.rediger.inntekt_frem_til_uttak.label':
-    'Pensjonsgivende inntekt frem til pensjon',
+    'Pensjonsgivende årsinntekt frem til pensjon',
   'beregning.avansert.rediger.inntekt_frem_til_endring.label':
-    'Pensjonsgivende inntekt frem til endring',
+    'Pensjonsgivende årsinntekt frem til endring',
   'beregning.avansert.rediger.inntekt_frem_til_uttak.description_ufoere':
     'Uten uføretrygd og uførepensjon.',
   'beregning.avansert.rediger.inntekt_frem_til_uttak.description':


### PR DESCRIPTION
I avansert skjema, i felt for pensjonsgivende inntekt frem til pensjon/endring (øverst i skjemaet)

For brukere:

    uten vedtak
    med vedtak om UT

legg til "års" slik at det blir "Pensjonsgivende årsinntekt frem til pensjon" (i stedet for "Pensjonsgivende inntekt frem til pensjon").

For brukere:

    med vedtak om AP

legg til "års" slik at det blir "Pensjonsgivende årsinntekt frem til endring" (i stedet for "Pensjonsgivende inntekt frem til endring").