### PR TITLE
Fix/pek 371 tydeliggjoring av klikkbare soyler

### DIFF
--- a/cypress/e2e/pensjon/kalkulator/hovedhistorie.cy.ts
+++ b/cypress/e2e/pensjon/kalkulator/hovedhistorie.cy.ts
@@ -481,6 +481,7 @@ describe('Hovedhistorie', () => {
         cy.contains('61').should('not.exist')
         cy.contains('69').should('be.visible')
         cy.contains('87+').should('exist')
+        cy.contains('Klikk på søylene for detaljer').should('exist')
       })
 
       it('forventer jeg en egen tabell med oversikt over mine pensjonsavtaler. Jeg må kunne trykke på trykk vis mer for å se all informasjon, og vis mindre for å skjule informasjon om pensjonsavtaler.', () => {

--- a/src/components/Simulering/Simulering.module.scss
+++ b/src/components/Simulering/Simulering.module.scss
@@ -40,6 +40,35 @@
   }
 }
 
+.info-click {
+  display: none;
+}
+
+@media (min-width: variables.$a-breakpoint-lg) {
+  .info-click {
+    display: flex;
+    position: absolute;
+    top: 0.1rem;
+    right: 10px;
+    align-items: center;
+    gap: 4px;
+
+    p {
+      color: var(--a-text-subtle);
+    }
+
+    svg {
+      color: var(--a-icon-subtle);
+      height: 24px;
+      width: 24px;
+    }
+  }
+
+  .highcharts-wrapper {
+    position: relative;
+  }
+}
+
 .tooltip {
   right: 0.375rem;
   background-color: var(--a-white);

--- a/src/components/Simulering/Simulering.module.scss
+++ b/src/components/Simulering/Simulering.module.scss
@@ -40,12 +40,12 @@
   }
 }
 
-.info-click {
+.infoClick {
   display: none;
 }
 
 @media (min-width: variables.$a-breakpoint-lg) {
-  .info-click {
+  .infoClick {
     display: flex;
     position: absolute;
     top: 0.1rem;
@@ -53,18 +53,13 @@
     align-items: center;
     gap: 4px;
 
-    p {
-      color: var(--a-text-subtle);
-    }
-
-    svg {
-      color: var(--a-icon-subtle);
-      height: 24px;
+    & > svg {
       width: 24px;
+      height: 24px;
     }
   }
 
-  .highcharts-wrapper {
+  .highchartsWrapper {
     position: relative;
   }
 }

--- a/src/components/Simulering/Simulering.module.scss.d.ts
+++ b/src/components/Simulering/Simulering.module.scss.d.ts
@@ -2,6 +2,8 @@ declare const classNames: {
   readonly section: "section";
   readonly title: "title";
   readonly loader: "loader";
+  readonly "info-click": "info-click";
+  readonly "highcharts-wrapper": "highcharts-wrapper";
   readonly tooltip: "tooltip";
   readonly tooltipTable: "tooltipTable";
   readonly tooltipLine: "tooltipLine";

--- a/src/components/Simulering/Simulering.module.scss.d.ts
+++ b/src/components/Simulering/Simulering.module.scss.d.ts
@@ -2,8 +2,8 @@ declare const classNames: {
   readonly section: "section";
   readonly title: "title";
   readonly loader: "loader";
-  readonly "info-click": "info-click";
-  readonly "highcharts-wrapper": "highcharts-wrapper";
+  readonly infoClick: "infoClick";
+  readonly highchartsWrapper: "highchartsWrapper";
   readonly tooltip: "tooltip";
   readonly tooltipTable: "tooltipTable";
   readonly tooltipLine: "tooltipLine";

--- a/src/components/Simulering/Simulering.tsx
+++ b/src/components/Simulering/Simulering.tsx
@@ -206,7 +206,9 @@ export function Simulering(props: {
           />
           <div className={styles['info-click']}>
             <HandFingerIcon />
-            <BodyShort size="small">Klikk på søylene for detaljer</BodyShort>
+            <BodyShort size="small">
+              <FormattedMessage id="beregning.highcharts.informasjon_klikk" />
+            </BodyShort>
           </div>
         </div>
       </div>

--- a/src/components/Simulering/Simulering.tsx
+++ b/src/components/Simulering/Simulering.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
 
-import { Heading, HeadingProps } from '@navikt/ds-react'
+import { HandFingerIcon } from '@navikt/aksel-icons'
+import { BodyShort, Heading, HeadingProps } from '@navikt/ds-react'
 import Highcharts, { SeriesColumnOptions, XAxisOptions } from 'highcharts'
 import HighchartsReact from 'highcharts-react-official'
 
@@ -193,12 +194,20 @@ export function Simulering(props: {
         <div id="alt-chart-title" hidden>
           <FormattedMessage id="beregning.alt_tekst" />
         </div>
-        <div data-testid="highcharts-aria-wrapper" aria-hidden={true}>
+        <div
+          className={styles['highcharts-wrapper']}
+          data-testid="highcharts-aria-wrapper"
+          aria-hidden={true}
+        >
           <HighchartsReact
             ref={chartRef}
             highcharts={Highcharts}
             options={chartOptions}
           />
+          <div className={styles['info-click']}>
+            <HandFingerIcon />
+            <BodyShort size="small">Klikk på søylene for detaljer</BodyShort>
+          </div>
         </div>
       </div>
       {showButtonsAndTable && (

--- a/src/components/Simulering/Simulering.tsx
+++ b/src/components/Simulering/Simulering.tsx
@@ -195,7 +195,7 @@ export function Simulering(props: {
           <FormattedMessage id="beregning.alt_tekst" />
         </div>
         <div
-          className={styles['highcharts-wrapper']}
+          className={styles.highchartsWrapper}
           data-testid="highcharts-aria-wrapper"
           aria-hidden={true}
         >
@@ -204,12 +204,15 @@ export function Simulering(props: {
             highcharts={Highcharts}
             options={chartOptions}
           />
-          <div className={styles['info-click']}>
+
+          <BodyShort
+            size="small"
+            textColor="subtle"
+            className={styles.infoClick}
+          >
             <HandFingerIcon />
-            <BodyShort size="small">
-              <FormattedMessage id="beregning.highcharts.informasjon_klikk" />
-            </BodyShort>
-          </div>
+            <FormattedMessage id="beregning.highcharts.informasjon_klikk" />
+          </BodyShort>
         </div>
       </div>
       {showButtonsAndTable && (

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -394,6 +394,7 @@ const translations = {
   'beregning.title': 'Calculation',
   'beregning.alert.inntekt':
     'Because you have changed your income, your pension accrual changes.',
+  'beregning.highcharts.informasjon_klikk': 'MANGLER_TEKST',
   'beregning.highcharts.title': 'Calculation',
   'beregning.highcharts.xaxis': 'Annual Income and Pension after Withdrawal',
   'beregning.highcharts.yaxis': 'Currency',

--- a/src/translations/nb.ts
+++ b/src/translations/nb.ts
@@ -400,6 +400,7 @@ const translations = {
   'beregning.title': 'Beregning',
   'beregning.alert.inntekt':
     'Fordi du har endret inntekten din, endres pensjonsopptjeningen din.',
+  'beregning.highcharts.informasjon_klikk': 'Klikk på søylene for detaljer',
   'beregning.highcharts.title': 'Beregning',
   'beregning.highcharts.xaxis': 'Årlig inntekt og pensjon etter uttak',
   'beregning.highcharts.yaxis': 'Kroner',

--- a/src/translations/nn.ts
+++ b/src/translations/nn.ts
@@ -332,6 +332,7 @@ const translations = {
     'Du har pensjonsavtalar som startar før valgt alder. Sjå detaljar i grunnlaget under.',
   'beregning.title': 'Utrekning',
   'beregning.alert.inntekt': 'MANGLER_TEKST',
+  'beregning.highcharts.informasjon_klikk': 'MANGLER_TEKST',
   'beregning.highcharts.title': 'Utrekning',
   'beregning.highcharts.xaxis': 'Årleg inntekt og pensjon etter uttak',
   'beregning.highcharts.yaxis': 'Kroner',


### PR DESCRIPTION
Lagt til en informasjonstekst som forteller brukeren at søylene kan trykkes på

<img width="1073" alt="image" src="https://github.com/user-attachments/assets/b4f8d4d7-3a7c-4cd7-94f3-9dc7a3889507" />
