### PR TITLE
Fjern logging av feil fra Sanity ved !response.ok

### DIFF
--- a/src/context/LanguageProvider/LanguageProvider.tsx
+++ b/src/context/LanguageProvider/LanguageProvider.tsx
@@ -53,12 +53,6 @@ export function LanguageProvider({ children }: Props) {
         `*[_type == "readmore" && language == "${locale}"] | {name,overskrift,innhold}`
       )
       .then((sanityReadMoreResponse) => {
-        if (!sanityReadMoreResponse.ok) {
-          logger('info', {
-            tekst: `${logTekst} med status: ${sanityReadMoreResponse.status}`,
-            data: logData,
-          })
-        }
         setSanityReadMoreData(
           Object.fromEntries(
             (sanityReadMoreResponse || []).map((readmore: SanityReadMore) => [
@@ -79,12 +73,6 @@ export function LanguageProvider({ children }: Props) {
         `*[_type == "forbeholdAvsnitt" && language == "${locale}"] | order(order asc) | {overskrift,innhold}`
       )
       .then((sanityForbeholdAvsnittResponse) => {
-        if (!sanityForbeholdAvsnittResponse.ok) {
-          logger('info', {
-            tekst: `${logTekst} med status: ${sanityForbeholdAvsnittResponse.status}`,
-            data: logData,
-          })
-        }
         setSanityForbeholdAvsnittData(sanityForbeholdAvsnittResponse || [])
       })
       .catch(() => {


### PR DESCRIPTION
Oppdaget feil i Sanity-integrasjonen der systemet logger feilmeldinger uavhengig av faktisk respons. Dette skjer fordi Sanity returnerer et array-objekt, noe som gjør at response.ok aldri blir `true`. Resultatet er at alle responser logges som feilende.

Dette er en unødvendig validering siden vi allerede har en catch-funksjon i samme promise-kjede som håndterer faktiske feil.