### PR TITLE
Quickfix: Endret z-index på highcharts til 1 ved break point lg

### DIFF
--- a/src/components/Simulering/Simulering.module.scss
+++ b/src/components/Simulering/Simulering.module.scss
@@ -182,6 +182,12 @@
 }
 
 :global {
+  @media (min-width: variables.$a-breakpoint-lg) {
+    .highcharts-container {
+      z-index: 1 !important;
+    }
+  }
+
   .highcharts-loading {
     opacity: 1 !important;
     background-color: rgb(255 255 255 / 70%) !important;

--- a/src/components/Simulering/Simulering.module.scss.d.ts
+++ b/src/components/Simulering/Simulering.module.scss.d.ts
@@ -7,6 +7,7 @@ declare const classNames: {
   readonly tooltip: "tooltip";
   readonly tooltipTable: "tooltipTable";
   readonly tooltipLine: "tooltipLine";
+  readonly "highcharts-container": "highcharts-container";
   readonly "highcharts-scrolling-parent": "highcharts-scrolling-parent";
   readonly "highcharts-axis-labels": "highcharts-axis-labels";
   readonly "highcharts-yaxis-labels": "highcharts-yaxis-labels";
@@ -19,7 +20,6 @@ declare const classNames: {
   readonly "highcharts-loading": "highcharts-loading";
   readonly "highcharts-loading-inner": "highcharts-loading-inner";
   readonly "highcharts-tooltip-container": "highcharts-tooltip-container";
-  readonly "highcharts-container": "highcharts-container";
   readonly "highcharts-scrollable-mask": "highcharts-scrollable-mask";
   readonly "highcharts-root": "highcharts-root";
   readonly "highcharts-background": "highcharts-background";


### PR DESCRIPTION
Tooltip på highcharts gikk under infoelement. Ved å endre z-index til 1 er den nå over.
Fra dette:
<img width="483" alt="Skjermbilde 2025-03-19 kl  12 35 37" src="https://github.com/user-attachments/assets/a33780e3-b42b-4222-b6dc-69a56ce59f20" />
Til dette:
<img width="441" alt="Skjermbilde 2025-03-19 kl  12 35 48" src="https://github.com/user-attachments/assets/49a60032-2af0-4261-aef7-138ddb345bd7" />
