### PR TITLE
PEK-1115: Optimaliser arbeidsflyt for test-miljøer ved å kjøre tester parallelt med utrulling

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -223,7 +223,7 @@ jobs:
 
   deploy-sandbox:
     name: Deploy to sandbox
-    needs: [build, run-unit-tests, run-integration-tests]
+    needs: [build]
     permissions:
       id-token: 'write'
     runs-on: ubuntu-latest
@@ -254,7 +254,7 @@ jobs:
 
   deploy-catbox:
     name: Deploy to catbox
-    needs: [build, run-unit-tests, run-integration-tests]
+    needs: [build]
     permissions:
       id-token: 'write'
     runs-on: ubuntu-latest
@@ -283,7 +283,7 @@ jobs:
 
   deploy-magicbox:
     name: Deploy to magicbox
-    needs: [build, run-unit-tests, run-integration-tests]
+    needs: [build]
     permissions:
       id-token: 'write'
     runs-on: ubuntu-latest
@@ -312,7 +312,7 @@ jobs:
 
   deploy-dreambox:
     name: Deploy to dreambox
-    needs: [build, run-unit-tests, run-integration-tests]
+    needs: [build]
     permissions:
       id-token: 'write'
     runs-on: ubuntu-latest
@@ -341,7 +341,7 @@ jobs:
 
   deploy-coffeebox:
     name: Deploy to coffeebox
-    needs: [build, run-unit-tests, run-integration-tests]
+    needs: [build]
     permissions:
       id-token: 'write'
     runs-on: ubuntu-latest
@@ -370,7 +370,7 @@ jobs:
 
   deploy-codebox:
     name: Deploy to codebox
-    needs: [build, run-unit-tests, run-integration-tests]
+    needs: [build]
     permissions:
       id-token: 'write'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Dette gjør at vi kan rulle ut endringer til test-miljøer (sandbox, catbox, magicbox, dreambox, coffeebox, codebox) uten å vente på at testene er fullført. Dette gir raskere tilbakemelding på endringer i utviklingsmiljøene.

- Tester kjøres fortsatt, men blokkerer ikke utrulling til test-miljøer
- Utrulling til staging og produksjon krever fortsatt at alle tester passerer

Eksempel på bygg i `sandbox`: https://github.com/navikt/pensjonskalkulator-frontend/actions/runs/13993167435