### PR TITLE
Fjern ubrukt pakke @eslint/eslintrc

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
       - npm-github
     schedule:
       interval: daily
+    versioning-strategy: increase
     groups:
       designsystemet:
         patterns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
       },
       "devDependencies": {
         "@babel/plugin-syntax-import-attributes": "^7.26.0",
-        "@eslint/eslintrc": "^3.3.0",
         "@eslint/js": "^9.22.0",
         "@formatjs/ecma402-abstract": "^2.3.1",
         "@formatjs/intl-numberformat": "^8.15.3",
@@ -45,7 +44,7 @@
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/coverage-v8": "^3.0.9",
-        "@vitest/ui": "^3.0.6",
+        "@vitest/ui": "^3.0.9",
         "axe-core": "^4.10.3",
         "clsx": "^2.1.1",
         "cypress": "^14.2.0",
@@ -87,7 +86,7 @@
         "vite-plugin-sass-dts": "^1.3.31",
         "vite-plugin-stylelint": "^6.0.0",
         "vite-tsconfig-paths": "^5.1.4",
-        "vitest": "^3.0.6"
+        "vitest": "^3.0.9"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@babel/plugin-syntax-import-attributes": "^7.26.0",
-    "@eslint/eslintrc": "^3.3.0",
     "@eslint/js": "^9.22.0",
     "@formatjs/ecma402-abstract": "^2.3.1",
     "@formatjs/intl-numberformat": "^8.15.3",
@@ -71,7 +70,7 @@
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "^3.0.9",
-    "@vitest/ui": "^3.0.6",
+    "@vitest/ui": "^3.0.9",
     "axe-core": "^4.10.3",
     "clsx": "^2.1.1",
     "cypress": "^14.2.0",
@@ -113,7 +112,7 @@
     "vite-plugin-sass-dts": "^1.3.31",
     "vite-plugin-stylelint": "^6.0.0",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.0.6"
+    "vitest": "^3.0.9"
   },
   "msw": {
     "workerDirectory": "public"


### PR DESCRIPTION
Fjerner @eslint/eslintrc:
https://www.npmjs.com/package/@eslint/eslintrc
> This package is not intended for use outside of the ESLint ecosystem.

Legger til `versioning-strategy: increase` i dependabot.yml i forsøk på å fikse et lite problem med at Dependabot ikke bumper alle pakker i gruppen "vitest" i package.json (eksempel: https://github.com/navikt/pensjonskalkulator-frontend/pull/1928/files). (Den bumper i lock-fila, så ikke noe stort problem.)