### PR TITLE
Fjern @formatjs/ecma402-abstract fra dev-deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
       "devDependencies": {
         "@babel/plugin-syntax-import-attributes": "^7.26.0",
         "@eslint/js": "^9.23.0",
-        "@formatjs/ecma402-abstract": "^2.3.1",
         "@formatjs/intl-numberformat": "^8.15.3",
         "@grafana/faro-web-sdk": "^1.14.1",
         "@grafana/faro-web-tracing": "^1.14.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "@babel/plugin-syntax-import-attributes": "^7.26.0",
     "@eslint/js": "^9.23.0",
-    "@formatjs/ecma402-abstract": "^2.3.1",
     "@formatjs/intl-numberformat": "^8.15.3",
     "@grafana/faro-web-sdk": "^1.14.1",
     "@grafana/faro-web-tracing": "^1.14.1",


### PR DESCRIPTION
Brukes ikke direkte noe sted, så ser ikke noe poeng i å ha den i devDependencies.