### PR TITLE
AFP-Uføre: Vis AFP i resultatet hvis du har valgt å beregne AFP

### DIFF
--- a/src/pages/Beregning/BeregningAvansert.tsx
+++ b/src/pages/Beregning/BeregningAvansert.tsx
@@ -231,14 +231,12 @@ export const BeregningAvansert: React.FC = () => {
               aarligInntektFoerUttakBeloep={aarligInntektFoerUttakBeloep ?? '0'}
               alderspensjonListe={alderspensjon?.alderspensjon}
               afpPrivatListe={
-                !loependeVedtak.ufoeretrygd.grad &&
                 (afp === 'ja_privat' || loependeVedtak.afpPrivat) &&
                 alderspensjon?.afpPrivat
                   ? alderspensjon?.afpPrivat
                   : undefined
               }
               afpOffentligListe={
-                !loependeVedtak.ufoeretrygd.grad &&
                 afp === 'ja_offentlig' &&
                 harSamtykketOffentligAFP &&
                 alderspensjon?.afpOffentlig


### PR DESCRIPTION
Så vidt jeg kan se så får vi ikke afpPrivat og afpOffentlig tilbake fra backend med mindre vi har bedt om det. I `getSimuleringstypeFromRadioEllerVedtak()` så ser du at vi ikke ber om AFP hvis personen har uføretrygd, med mindre man har valgt beregningsvalg=med_afp. Ergo skal det ikke være nødvendig å sjekke uføregrad på nytt i BeregningAvansert.

Det er sikkert flere sjekker som kunne vært fjernet fra BeregningAvansert, men tenker det er tryggest å endre minst mulig 😅