### PR TITLE
PEK-694: Vis uventet feil hvis off afp ikke inkluderes

### DIFF
--- a/src/pages/Beregning/BeregningAvansert.tsx
+++ b/src/pages/Beregning/BeregningAvansert.tsx
@@ -134,9 +134,12 @@ export const BeregningAvansert: React.FC = () => {
 
   React.useEffect(() => {
     if (
-      error &&
-      ((error as FetchBaseQueryError).status === 503 ||
-        (error as FetchBaseQueryError).status === 'PARSING_ERROR')
+      (error &&
+        ((error as FetchBaseQueryError).status === 503 ||
+          (error as FetchBaseQueryError).status === 'PARSING_ERROR')) ||
+      (alderspensjon?.afpOffentlig?.length === 0 &&
+        alderspensjonRequestBody?.simuleringstype ===
+          'ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG')
     ) {
       navigate(paths.uventetFeil)
       logger('info', {
@@ -144,7 +147,7 @@ export const BeregningAvansert: React.FC = () => {
         data: 'fra Beregning Avansert',
       })
     }
-  }, [error])
+  }, [error, alderspensjon])
 
   // Skal redigerer tilbake når alderspensjon er refetchet ferdig, og
   React.useEffect(() => {

--- a/src/state/api/apiSlice.ts
+++ b/src/state/api/apiSlice.ts
@@ -19,6 +19,7 @@ import {
   isEkskludertStatus,
   isOmstillingsstoenadOgGjenlevende,
   isLoependeVedtak,
+  isUttaksalderError,
 } from './typeguards'
 
 export const apiSlice = createApi({
@@ -149,7 +150,7 @@ export const apiSlice = createApi({
     }),
 
     tidligstMuligHeltUttak: builder.query<
-      Alder,
+      Alder | UttaksalderError,
       TidligstMuligHeltUttakRequestBody | void
     >({
       query: (body) => ({
@@ -157,7 +158,11 @@ export const apiSlice = createApi({
         method: 'POST',
         body,
       }),
-      transformResponse: (response: Alder) => {
+      transformResponse: (response: Alder | UttaksalderError, meta) => {
+        if (meta?.response?.status === 500 && isUttaksalderError(response)) {
+          return response as UttaksalderError
+        }
+
         if (!isAlder(response)) {
           throw new Error(`Mottok ugyldig uttaksalder: ${response}`)
         }

--- a/src/state/api/typeguards.ts
+++ b/src/state/api/typeguards.ts
@@ -326,6 +326,15 @@ export const isAlder = (data?: any): data is Alder => {
   )
 }
 
+export const isUttaksalderError = (data?: any): data is UttaksalderError => {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    !Array.isArray(data) &&
+    typeof (data as UttaksalderError).errorCode === 'string'
+  )
+}
+
 export const isSomeEnumKey =
   <T extends { [s: string]: unknown }>(e: T) =>
   (token: unknown): token is T[keyof T] => {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -304,26 +304,6 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/api/v1/vedtak/loepende-vedtak': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /**
-     * Har løpende vedtak
-     * @description Hvorvidt den innloggede brukeren har løpende uføretrygd med uttaksgrad, alderspensjon med uttaksgrad, AFP i privat eller offentlig sektor
-     */
-    get: operations['hentLoependeVedtakV1']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   '/api/v1/ufoeregrad': {
     parameters: {
       query?: never
@@ -574,6 +554,7 @@ export interface components {
       /** @enum {string} */
       simuleringstype:
         | 'ALDERSPENSJON'
+        | 'PRE2025_OFFENTLIG_AFP_ETTERFULGT_AV_ALDERSPENSJON'
         | 'ALDERSPENSJON_MED_AFP_PRIVAT'
         | 'ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG'
         | 'ENDRING_ALDERSPENSJON'
@@ -602,6 +583,17 @@ export interface components {
         | 'SAMBOER'
       epsHarInntektOver2G: boolean
       epsHarPensjon: boolean
+      /** Format: int32 */
+      afpInntektMaanedFoerUttak?: number
+      /** @enum {string} */
+      afpOrdning?:
+        | 'AFPKOM'
+        | 'AFPSTAT'
+        | 'FINANS'
+        | 'KONV_K'
+        | 'KONV_O'
+        | 'LONHO'
+        | 'NAVO'
     }
     PersonligSimuleringUtenlandsperiodeSpecV8: {
       /** Format: date */
@@ -679,9 +671,36 @@ export interface components {
       /** Format: int32 */
       heltUttakMaanedligBeloep: number
     }
+    PersonligSimuleringPre2025OffentligAfpResultV8: {
+      /** Format: int32 */
+      alderAar: number
+      /** Format: int32 */
+      totaltAfpBeloep: number
+      /** Format: int32 */
+      tidligereArbeidsinntekt: number
+      /** Format: int32 */
+      grunnbeloep: number
+      /** Format: double */
+      sluttpoengtall: number
+      /** Format: int32 */
+      trygdetid: number
+      /** Format: int32 */
+      poengaarTom1991: number
+      /** Format: int32 */
+      poengaarFom1992: number
+      /** Format: int32 */
+      grunnpensjon: number
+      /** Format: int32 */
+      tilleggspensjon: number
+      /** Format: int32 */
+      afpTillegg: number
+      /** Format: int32 */
+      saertillegg: number
+    }
     PersonligSimuleringResultV8: {
       alderspensjon: components['schemas']['PersonligSimuleringAlderspensjonResultV8'][]
       alderspensjonMaanedligVedEndring?: components['schemas']['PersonligSimuleringMaanedligPensjonResultV8']
+      pre2025OffentligAfp?: components['schemas']['PersonligSimuleringPre2025OffentligAfpResultV8']
       afpPrivat?: components['schemas']['PersonligSimuleringAarligPensjonResultV8'][]
       afpOffentlig?: components['schemas']['PersonligSimuleringAarligPensjonResultV8'][]
       vilkaarsproeving: components['schemas']['PersonligSimuleringVilkaarsproevingResultV8']
@@ -780,6 +799,7 @@ export interface components {
       /** @enum {string} */
       simuleringstype?:
         | 'ALDERSPENSJON'
+        | 'PRE2025_OFFENTLIG_AFP_ETTERFULGT_AV_ALDERSPENSJON'
         | 'ALDERSPENSJON_MED_AFP_PRIVAT'
         | 'ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG'
         | 'ENDRING_ALDERSPENSJON'
@@ -813,6 +833,11 @@ export interface components {
       tom?: string
       landkode: string
       arbeidetUtenlands: boolean
+    }
+    UttaksalderError: {
+      /** @enum {string} */
+      errorCode: 'AFP_IKKE_I_VILKAARSPROEVING'
+      cause?: string
     }
     UttaksalderResultV2: {
       /** Format: int32 */
@@ -966,6 +991,7 @@ export interface components {
       /** @enum {string} */
       simuleringstype?:
         | 'ALDERSPENSJON'
+        | 'PRE2025_OFFENTLIG_AFP_ETTERFULGT_AV_ALDERSPENSJON'
         | 'ALDERSPENSJON_MED_AFP_PRIVAT'
         | 'ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG'
         | 'ENDRING_ALDERSPENSJON'
@@ -1292,19 +1318,6 @@ export interface components {
       /** @enum {string} */
       aarsak: 'NONE' | 'ER_APOTEKER'
     }
-    LoependeVedtakDetaljerV1: {
-      loepende: boolean
-      /** Format: int32 */
-      grad: number
-      /** Format: date */
-      fom?: string
-    }
-    LoependeVedtakV1: {
-      alderspensjon: components['schemas']['LoependeVedtakDetaljerV1']
-      ufoeretrygd: components['schemas']['LoependeVedtakDetaljerV1']
-      afpPrivat: components['schemas']['LoependeVedtakDetaljerV1']
-      afpOffentlig: components['schemas']['LoependeVedtakDetaljerV1']
-    }
     UfoeregradDto: {
       /** Format: int32 */
       ufoeregrad: number
@@ -1455,7 +1468,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          '*/*': unknown
+          '*/*': components['schemas']['UttaksalderError']
         }
       }
     }
@@ -1822,35 +1835,6 @@ export interface operations {
         }
       }
       /** @description Sjekking av ekskludering kunne ikke utføres av tekniske årsaker */
-      503: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          '*/*': unknown
-        }
-      }
-    }
-  }
-  hentLoependeVedtakV1: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Henting av løpende vedtak utført */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          '*/*': components['schemas']['LoependeVedtakV1']
-        }
-      }
-      /** @description Henting av løpende vedtak kunne ikke utføres av tekniske årsaker */
       503: {
         headers: {
           [name: string]: unknown

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -15,6 +15,7 @@ declare global {
   type BeregningVisning = 'enkel' | 'avansert'
   type Beregningsvalg = 'uten_afp' | 'med_afp'
   type Alder = components['schemas']['Alder']
+  type UttaksalderError = components['schemas']['UttaksalderError']
 
   type UnleashToggle = components['schemas']['EnablementDto']
 


### PR DESCRIPTION
Redirecter til uventet feil siden dersom AFPOffentlig er tom (vil si at AFP ikke er med i vilkårsprøvingen)