### PR TITLE
Fjern aria-required og role=radiogroup

### DIFF
--- a/src/components/AvansertSkjema/AvansertSkjemaForAndreBrukere/AvansertSkjemaForAndreBrukere.tsx
+++ b/src/components/AvansertSkjema/AvansertSkjemaForAndreBrukere/AvansertSkjemaForAndreBrukere.tsx
@@ -458,7 +458,6 @@ export const AvansertSkjemaForAndreBrukere: React.FC<{
                     )
                   : ''
               }
-              aria-required="true"
             >
               <option disabled value="">
                 {' '}
@@ -537,8 +536,6 @@ export const AvansertSkjemaForAndreBrukere: React.FC<{
                           )
                         : ''
                     }
-                    role="radiogroup"
-                    aria-required="true"
                   >
                     <Radio
                       form={AVANSERT_FORM_NAMES.form}
@@ -609,7 +606,6 @@ export const AvansertSkjemaForAndreBrukere: React.FC<{
                     }
                     onChange={handleInntektVsaGradertUttakChange}
                     value={localGradertUttak.aarligInntektVsaPensjonBeloep}
-                    aria-required="true"
                   />
                 )}
 
@@ -667,8 +663,6 @@ export const AvansertSkjemaForAndreBrukere: React.FC<{
                       )
                     : ''
                 }
-                role="radiogroup"
-                aria-required="true"
               >
                 <Radio
                   form={AVANSERT_FORM_NAMES.form}
@@ -728,7 +722,6 @@ export const AvansertSkjemaForAndreBrukere: React.FC<{
                   }
                   onChange={handleInntektVsaHeltUttakChange}
                   value={localHeltUttak.aarligInntektVsaPensjon?.beloep}
-                  aria-required="true"
                 />
 
                 <AgePicker

--- a/src/components/AvansertSkjema/AvansertSkjemaForBrukereMedGradertUfoeretrygd/AvansertSkjemaForBrukereMedGradertUfoeretrygd.tsx
+++ b/src/components/AvansertSkjema/AvansertSkjemaForBrukereMedGradertUfoeretrygd/AvansertSkjemaForBrukereMedGradertUfoeretrygd.tsx
@@ -576,7 +576,6 @@ export const AvansertSkjemaForBrukereMedGradertUfoeretrygd: React.FC<{
                         )
                       : ''
                   }
-                  aria-required="true"
                 >
                   <option disabled value="">
                     {' '}
@@ -660,8 +659,6 @@ export const AvansertSkjemaForBrukereMedGradertUfoeretrygd: React.FC<{
                               )
                             : ''
                         }
-                        role="radiogroup"
-                        aria-required="true"
                       >
                         <Radio
                           form={AVANSERT_FORM_NAMES.form}
@@ -732,7 +729,6 @@ export const AvansertSkjemaForBrukereMedGradertUfoeretrygd: React.FC<{
                         }
                         onChange={handleInntektVsaGradertUttakChange}
                         value={localGradertUttak.aarligInntektVsaPensjonBeloep}
-                        aria-required="true"
                       />
                     )}
 
@@ -796,8 +792,6 @@ export const AvansertSkjemaForBrukereMedGradertUfoeretrygd: React.FC<{
                           )
                         : ''
                     }
-                    role="radiogroup"
-                    aria-required="true"
                   >
                     <Radio
                       form={AVANSERT_FORM_NAMES.form}
@@ -859,7 +853,6 @@ export const AvansertSkjemaForBrukereMedGradertUfoeretrygd: React.FC<{
                       }
                       onChange={handleInntektVsaHeltUttakChange}
                       value={localHeltUttak.aarligInntektVsaPensjon?.beloep}
-                      aria-required="true"
                     />
 
                     <AgePicker

--- a/src/components/AvansertSkjema/AvansertSkjemaForBrukereMedGradertUfoeretrygd/Beregningsvalg/Beregningsvalg.tsx
+++ b/src/components/AvansertSkjema/AvansertSkjemaForBrukereMedGradertUfoeretrygd/Beregningsvalg/Beregningsvalg.tsx
@@ -29,8 +29,6 @@ export const Beregningsvalg = ({
         legend={intl.formatMessage({
           id: 'beregning.avansert.rediger.radio.beregningsvalg.label',
         })}
-        role="radiogroup"
-        aria-required="true"
         name={AVANSERT_FORM_NAMES.beregningsTypeRadio}
         data-testid={AVANSERT_FORM_NAMES.beregningsTypeRadio}
         value={localBeregningsTypeRadio}

--- a/src/components/UtenlandsoppholdModal/UtenlandsoppholdModal.tsx
+++ b/src/components/UtenlandsoppholdModal/UtenlandsoppholdModal.tsx
@@ -144,7 +144,6 @@ export const UtenlandsoppholdModal: React.FC<Props> = ({
                     )
                   : ''
               }
-              aria-required="true"
             >
               <option disabled value="">
                 {' '}
@@ -220,8 +219,6 @@ export const UtenlandsoppholdModal: React.FC<Props> = ({
                           )
                         : ''
                     }
-                    role="radiogroup"
-                    aria-required="true"
                   >
                     <Radio
                       value="ja"

--- a/src/components/common/AgePicker/AgePicker.tsx
+++ b/src/components/common/AgePicker/AgePicker.tsx
@@ -155,7 +155,6 @@ export const AgePicker = ({
           }}
           aria-describedby={hasError.maaneder ? `${name}-error` : undefined}
           aria-invalid={hasError.aar}
-          aria-required
         >
           <option disabled value="">
             {' '}
@@ -194,7 +193,6 @@ export const AgePicker = ({
           disabled={!valgtAlder.aar}
           aria-describedby={hasError.maaneder ? `${name}-error` : undefined}
           aria-invalid={hasError.maaneder}
-          aria-required
         >
           <option disabled value="">
             {' '}

--- a/src/components/stegvisning/AFP/AFPOvergangskull/AFPOvergangskullUtenAP.tsx
+++ b/src/components/stegvisning/AFP/AFPOvergangskull/AFPOvergangskullUtenAP.tsx
@@ -167,8 +167,6 @@ export function AFPOvergangskullUtenAP({
               })
             }
             error={validationError.skalBeregneAfpError}
-            role="radiogroup"
-            aria-required="true"
           >
             <Radio value="ja">
               <FormattedMessage id="stegvisning.afp.overgangskullUtenAP.radio_ja" />

--- a/src/components/stegvisning/AFP/AFPPrivat/AFPPrivat.tsx
+++ b/src/components/stegvisning/AFP/AFPPrivat/AFPPrivat.tsx
@@ -79,8 +79,6 @@ export function AFPPrivat({
           defaultValue={previousAfp}
           onChange={() => setValidationError('')}
           error={validationError}
-          role="radiogroup"
-          aria-required="true"
         >
           <Radio value="ja_privat">
             <FormattedMessage id="stegvisning.radio_ja" />

--- a/src/components/stegvisning/AFP/AFPRadiogroup.tsx
+++ b/src/components/stegvisning/AFP/AFPRadiogroup.tsx
@@ -26,8 +26,6 @@ const AFPRadioGroup: React.FC<AFPRadioGroupProps> = ({
     defaultValue={afp}
     onChange={handleRadioChange}
     error={validationError}
-    role="radiogroup"
-    aria-required="true"
   >
     <Radio value="ja_offentlig">
       <FormattedMessage id="stegvisning.afp.radio_ja_offentlig" />

--- a/src/components/stegvisning/SamtykkeOffentligAFP/SamtykkeOffentligAFP.tsx
+++ b/src/components/stegvisning/SamtykkeOffentligAFP/SamtykkeOffentligAFP.tsx
@@ -91,8 +91,6 @@ export function SamtykkeOffentligAFP({
           }
           onChange={handleRadioChange}
           error={validationError}
-          role="radiogroup"
-          aria-required="true"
         >
           <Radio value="ja">
             <FormattedMessage id="stegvisning.samtykke_offentlig_afp.radio_ja" />

--- a/src/components/stegvisning/SamtykkePensjonsavtaler/SamtykkePensjonsavtaler.tsx
+++ b/src/components/stegvisning/SamtykkePensjonsavtaler/SamtykkePensjonsavtaler.tsx
@@ -98,8 +98,6 @@ export function SamtykkePensjonsavtaler({
           }
           onChange={handleRadioChange}
           error={validationError}
-          role="radiogroup"
-          aria-required="true"
         >
           <Radio value="ja">
             <FormattedMessage id="stegvisning.samtykke_pensjonsavtaler.radio_ja" />

--- a/src/components/stegvisning/Sivilstand/Sivilstand.tsx
+++ b/src/components/stegvisning/Sivilstand/Sivilstand.tsx
@@ -253,8 +253,6 @@ export function Sivilstand({
               value={epsHarPensjonInput}
               onChange={setEpsHarPensjonInput}
               error={validationError.epsHarPensjon}
-              role="radiogroup"
-              aria-required="true"
             >
               <Radio value="ja">
                 <FormattedMessage id="stegvisning.sivilstand.radio_ja" />
@@ -284,8 +282,6 @@ export function Sivilstand({
               onChange={(value) => setEpsHarInntektOver2GInput(value)}
               name="epsHarInntektOver2G"
               error={validationError.epsHarInntektOver2G}
-              role="radiogroup"
-              aria-required="true"
             >
               <Radio value="ja">
                 <FormattedMessage id="stegvisning.sivilstand.radio_ja" />

--- a/src/components/stegvisning/Sivilstand/__tests__/Sivilstand.test.tsx
+++ b/src/components/stegvisning/Sivilstand/__tests__/Sivilstand.test.tsx
@@ -83,17 +83,15 @@ describe('stegvisning - Sivilstand', () => {
             onNext={onNextMock}
           />
         )
-        const epsHarPensjonRadioGroup = screen.queryByRole('radiogroup', {
-          name: /Vil stegvisning.sivilstand.ektefellen motta pensjon eller uføretrygd fra folketrygden, eller AFP?/i,
+        const epsHarPensjonRadioGroup = screen.queryByRole('group', {
+          name: 'Vil stegvisning.sivilstand.ektefellen motta pensjon eller uføretrygd fra folketrygden, eller AFP?',
         })
-        const epsHarInntektOver2GRadioGroup = screen.queryByRole('radiogroup', {
-          name: /epsHarInntektOver2G/i,
+        const epsHarInntektOver2GRadioGroup = screen.queryByRole('group', {
+          name: 'epsHarInntektOver2G',
         })
 
-        await waitFor(() => {
-          expect(epsHarPensjonRadioGroup).toBeVisible()
-          expect(epsHarInntektOver2GRadioGroup).not.toBeInTheDocument()
-        })
+        expect(epsHarPensjonRadioGroup).toBeVisible()
+        expect(epsHarInntektOver2GRadioGroup).not.toBeInTheDocument()
       })
       describe('når sivilstanden din er gift, ', async () => {
         it('skal teksten for epsHarPensjon endres til "ektefellen din"', async () => {
@@ -109,13 +107,11 @@ describe('stegvisning - Sivilstand', () => {
             />
           )
 
-          await waitFor(() => {
-            expect(
-              screen.queryByRole('radiogroup', {
-                name: /Vil stegvisning.sivilstand.ektefellen motta pensjon eller uføretrygd fra folketrygden, eller AFP?/i,
-              })
-            ).toBeInTheDocument()
-          })
+          expect(
+            screen.queryByRole('group', {
+              name: 'Vil stegvisning.sivilstand.ektefellen motta pensjon eller uføretrygd fra folketrygden, eller AFP?',
+            })
+          ).toBeVisible()
         })
       })
       describe('når sivilstanden din er samboer, ', async () => {
@@ -132,13 +128,11 @@ describe('stegvisning - Sivilstand', () => {
             />
           )
 
-          await waitFor(() => {
-            expect(
-              screen.queryByRole('radiogroup', {
-                name: /Vil stegvisning.sivilstand.samboeren motta pensjon eller uføretrygd fra folketrygden, eller AFP?/i,
-              })
-            ).toBeInTheDocument()
-          })
+          expect(
+            screen.queryByRole('group', {
+              name: 'Vil stegvisning.sivilstand.samboeren motta pensjon eller uføretrygd fra folketrygden, eller AFP?',
+            })
+          ).toBeVisible()
         })
       })
       describe('når sivilstanden din er registrert partner, ', async () => {
@@ -155,13 +149,11 @@ describe('stegvisning - Sivilstand', () => {
             />
           )
 
-          await waitFor(() => {
-            expect(
-              screen.queryByRole('radiogroup', {
-                name: /Vil stegvisning.sivilstand.partneren motta pensjon eller uføretrygd fra folketrygden, eller AFP?/i,
-              })
-            ).toBeInTheDocument()
-          })
+          expect(
+            screen.queryByRole('group', {
+              name: 'Vil stegvisning.sivilstand.partneren motta pensjon eller uføretrygd fra folketrygden, eller AFP?',
+            })
+          ).toBeVisible()
         })
       })
     })
@@ -185,14 +177,12 @@ describe('stegvisning - Sivilstand', () => {
         const radioButtonJa = radioButtons[0]
         fireEvent.click(radioButtonJa)
 
-        const epsHarInntektOver2GRadioGroup = screen.queryByRole('radiogroup', {
-          name: /epsHarInntektOver2G/i,
+        const epsHarInntektOver2GRadioGroup = screen.queryByRole('group', {
+          name: 'epsHarInntektOver2G',
         })
 
-        await waitFor(() => {
-          expect(radioButtonJa).toBeChecked()
-          expect(epsHarInntektOver2GRadioGroup).not.toBeInTheDocument()
-        })
+        expect(radioButtonJa).toBeChecked()
+        expect(epsHarInntektOver2GRadioGroup).not.toBeInTheDocument()
       })
       it('validerer epsHarPensjon, viser feilmelding, fjerner feilmelding og kaller onNext når brukeren klikker på Neste', async () => {
         const user = userEvent.setup()
@@ -255,14 +245,12 @@ describe('stegvisning - Sivilstand', () => {
         )
         fireEvent.click(epsHarPensjonRadioButtonNei)
 
-        const epsHarInntektOver2GRadioGroup = screen.queryByRole('radiogroup', {
-          name: /Vil stegvisning.sivilstand.ektefellen ha inntekt over 2G?/i,
+        const epsHarInntektOver2GRadioGroup = screen.queryByRole('group', {
+          name: 'Vil stegvisning.sivilstand.ektefellen ha inntekt over 2G?',
         })
 
-        await waitFor(() => {
-          expect(epsHarPensjonRadioButtonNei).toBeChecked()
-          expect(epsHarInntektOver2GRadioGroup).toBeVisible()
-        })
+        expect(epsHarPensjonRadioButtonNei).toBeChecked()
+        expect(epsHarInntektOver2GRadioGroup).toBeVisible()
       })
     })
   })

--- a/src/components/stegvisning/Utenlandsopphold/Utenlandsopphold.tsx
+++ b/src/components/stegvisning/Utenlandsopphold/Utenlandsopphold.tsx
@@ -110,8 +110,6 @@ export function Utenlandsopphold({
         }
         onChange={handleRadioChange}
         error={validationErrors.top}
-        role="radiogroup"
-        aria-required="true"
       >
         <Radio form="har-utenlandsopphold" value="ja">
           <FormattedMessage id="stegvisning.utenlandsopphold.radio_ja" />


### PR DESCRIPTION
`aria-required` gjør at skjermleserbrukere får beskjed om at feltet er påkrevd. Fjerner det siden vi på startsiden skriver at du må "svare på alle spørsmålene". Siden alle felt er påkrevd uansett, gir det bare unødvendig støy for skjermleserbrukere. Dessuten er det inkonsekvent seende ikke får den samme informasjonen (ved hvert felt).

Fjerner i samme slengen `role=radiogroup` fordi det trolig bare ble satt for å kunne sette `aria-required`, og det er dårlig praksis å overstyre role unødvendig.