### PR TITLE
Check if user is 75 years plus 1 month to show the start page for 75

### DIFF
--- a/cypress/e2e/pensjon/kalkulator/hovedhistorie.cy.ts
+++ b/cypress/e2e/pensjon/kalkulator/hovedhistorie.cy.ts
@@ -76,7 +76,7 @@ describe('Hovedhistorie', () => {
       'yyyy-MM-dd'
     )
 
-    const foedselsdato75Plus = format(
+    const foedselsdato75Plus1Maaned = format(
       sub(new Date(), { years: 75, months: 1, days: 5 }),
       'yyyy-MM-dd'
     )
@@ -121,7 +121,7 @@ describe('Hovedhistorie', () => {
     })
 
     // 5
-    describe('Når jeg navigerer videre fra /login til /start og har fyllt 75 år,', () => {
+    describe('Når jeg navigerer videre fra /login til /start og har fyllt 75 år plus 1 måned,', () => {
       beforeEach(() => {
         cy.visit('/pensjon/kalkulator/')
         cy.wait('@getAuthSession')
@@ -129,7 +129,7 @@ describe('Hovedhistorie', () => {
           { method: 'GET', url: '/pensjon/kalkulator/api/v4/person' },
           {
             ...personMock,
-            foedselsdato: foedselsdato75Plus,
+            foedselsdato: foedselsdato75Plus1Maaned,
           }
         ).as('getPerson')
         cy.contains('button', 'Detaljert pensjonskalkulator').should(

--- a/src/components/stegvisning/Start/StartForBrukereFyllt75.tsx
+++ b/src/components/stegvisning/Start/StartForBrukereFyllt75.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import React from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
 
-import { BodyLong, Button, Heading } from '@navikt/ds-react'
+import { BodyLong, Button, HStack, Heading } from '@navikt/ds-react'
 
 import { Card } from '@/components/common/Card'
 import { externalUrls, paths } from '@/router/constants'
@@ -45,11 +45,10 @@ export function StartForBrukereFyllt75() {
             }}
           />
         </BodyLong>
-        <div className={styles.wrapperText}>
+        <HStack gap="4" marginBlock="6 0">
           <Button
             data-testid="start-brukere-fyllt-75-din-pensjon-button"
             type="submit"
-            className={styles.button}
             variant="primary"
             onClick={wrapLogger('button klikk', {
               tekst: 'Go til Din pensjon',
@@ -66,7 +65,7 @@ export function StartForBrukereFyllt75() {
           >
             <FormattedMessage id="stegvisning.start_brukere_fyllt_75.avbryt" />
           </Button>
-        </div>
+        </HStack>
       </div>
     </Card>
   )

--- a/src/pages/StepStart/StepStart.tsx
+++ b/src/pages/StepStart/StepStart.tsx
@@ -11,7 +11,7 @@ import { paths } from '@/router/constants'
 import { stepStartAccessGuard } from '@/router/loaders'
 import { useAppSelector } from '@/state/hooks'
 import { selectIsVeileder } from '@/state/userInput/selectors'
-import { isAlderOver75 } from '@/utils/alder'
+import { isAlderOver75Plus1Maaned } from '@/utils/alder'
 
 export function StepStart() {
   const intl = useIntl()
@@ -31,7 +31,7 @@ export function StepStart() {
 
   const isVeileder = useAppSelector(selectIsVeileder)
 
-  if (isAlderOver75(person.foedselsdato)) {
+  if (isAlderOver75Plus1Maaned(person.foedselsdato)) {
     return <StartForBrukereFyllt75 />
   }
 

--- a/src/utils/__tests__/alder.test.ts
+++ b/src/utils/__tests__/alder.test.ts
@@ -779,7 +779,7 @@ describe('alder-utils', () => {
       expect(actual).toBe(false)
     })
 
-    it('over 75 år plus 1 month', () => {
+    it('returnerer true når alder er 75 år og 1 måned', () => {
       const foedselsdato = '1950-04-30' // Month after user filled 75 today
       const actual = isAlderOver75Plus1Maaned(foedselsdato)
       expect(actual).toBe(true)

--- a/src/utils/__tests__/alder.test.ts
+++ b/src/utils/__tests__/alder.test.ts
@@ -15,6 +15,7 @@ import {
   getMaanedString,
   isAlderLikEllerOverAnnenAlder,
   isAlderOver,
+  isAlderOver75Plus1Maaned,
   isAlderOverAnnenAlder,
   isFoedselsdatoOverAlder,
   isFoedtFoer1963,
@@ -754,6 +755,45 @@ describe('alder-utils', () => {
     it('ikke over 63 år', () => {
       const foedselsdato = '1967-06-06' // 58 today
       const actual = isAlderOver(63)(foedselsdato)
+      expect(actual).toBe(false)
+    })
+  })
+
+  describe('isAlderOver75Plus1Maaned', () => {
+    beforeAll(() => {
+      vi.useFakeTimers().setSystemTime(new Date('2025-05-01'))
+    })
+
+    afterAll(() => {
+      vi.useRealTimers()
+    })
+
+    it('faketimers is set', () => {
+      const today = new Date()
+      expect(format(today, 'yyyy-MM-dd')).toBe('2025-05-01')
+    })
+
+    it('fyllt 75 år men ikke over 75 år plus 1 måned', () => {
+      const foedselsdato = '1950-05-01' // Still in the month user filled 75
+      const actual = isAlderOver75Plus1Maaned(foedselsdato)
+      expect(actual).toBe(false)
+    })
+
+    it('over 75 år plus 1 month', () => {
+      const foedselsdato = '1950-04-30' // Month after user filled 75 today
+      const actual = isAlderOver75Plus1Maaned(foedselsdato)
+      expect(actual).toBe(true)
+    })
+
+    it('over 76 år', () => {
+      const foedselsdato = '1949-05-31'
+      const actual = isAlderOver75Plus1Maaned(foedselsdato)
+      expect(actual).toBe(true)
+    })
+
+    it('ikke fyllt 75 år', () => {
+      const foedselsdato = '1967-05-01'
+      const actual = isAlderOver75Plus1Maaned(foedselsdato)
       expect(actual).toBe(false)
     })
   })

--- a/src/utils/__tests__/alder.test.ts
+++ b/src/utils/__tests__/alder.test.ts
@@ -773,7 +773,7 @@ describe('alder-utils', () => {
       expect(format(today, 'yyyy-MM-dd')).toBe('2025-05-01')
     })
 
-    it('fyllt 75 år men ikke over 75 år plus 1 måned', () => {
+    it('returnerer false når alder er 75, men ikke over 75 år og 1 måned', () => {
       const foedselsdato = '1950-05-01' // Still in the month user filled 75
       const actual = isAlderOver75Plus1Maaned(foedselsdato)
       expect(actual).toBe(false)

--- a/src/utils/__tests__/alder.test.ts
+++ b/src/utils/__tests__/alder.test.ts
@@ -785,7 +785,7 @@ describe('alder-utils', () => {
       expect(actual).toBe(true)
     })
 
-    it('over 76 år', () => {
+    it('returnerer true når alder er over 75 år og 1 måned', () => {
       const foedselsdato = '1949-04-30'
       const actual = isAlderOver75Plus1Maaned(foedselsdato)
       expect(actual).toBe(true)

--- a/src/utils/__tests__/alder.test.ts
+++ b/src/utils/__tests__/alder.test.ts
@@ -791,7 +791,7 @@ describe('alder-utils', () => {
       expect(actual).toBe(true)
     })
 
-    it('ikke fyllt 75 år', () => {
+    it('returnerer false når alder er under 75 år og 1 måned', () => {
       const foedselsdato = '1967-05-01'
       const actual = isAlderOver75Plus1Maaned(foedselsdato)
       expect(actual).toBe(false)

--- a/src/utils/__tests__/alder.test.ts
+++ b/src/utils/__tests__/alder.test.ts
@@ -768,7 +768,7 @@ describe('alder-utils', () => {
       vi.useRealTimers()
     })
 
-    it('faketimers is set', () => {
+    it('forventer at faketimer setter riktig dato', () => {
       const today = new Date()
       expect(format(today, 'yyyy-MM-dd')).toBe('2025-05-01')
     })

--- a/src/utils/__tests__/alder.test.ts
+++ b/src/utils/__tests__/alder.test.ts
@@ -786,7 +786,7 @@ describe('alder-utils', () => {
     })
 
     it('over 76 år', () => {
-      const foedselsdato = '1949-05-31'
+      const foedselsdato = '1949-04-30'
       const actual = isAlderOver75Plus1Maaned(foedselsdato)
       expect(actual).toBe(true)
     })

--- a/src/utils/alder.ts
+++ b/src/utils/alder.ts
@@ -1,7 +1,9 @@
 import {
+  addYears,
   differenceInMonths,
   differenceInYears,
   endOfDay,
+  endOfMonth,
   format,
   isAfter,
   isBefore,
@@ -93,7 +95,19 @@ export const isAlderOver =
   }
 
 export const isAlderOver67 = isAlderOver(67)
-export const isAlderOver75 = isAlderOver(75)
+
+export const isAlderOver75Plus1Maaned = (foedselsdato: string) => {
+  const parsedFoedselsdato = parse(
+    foedselsdato,
+    DATE_BACKEND_FORMAT,
+    new Date()
+  )
+
+  const foedselsdato75 = addYears(parsedFoedselsdato, 75)
+  const sisteDagIMaanedenFyllt75 = endOfMonth(foedselsdato75)
+
+  return isAfter(new Date(), sisteDagIMaanedenFyllt75)
+}
 
 export const isOvergangskull = (foedselsdato: string) => {
   const DATE_START = new Date(1954, 0, 0)


### PR DESCRIPTION
Del av oppgaven: [1184](https://jira.adeo.no/browse/PEK-1184) hvor ny aldersgrense ble avklart:

- Alders grense for å sjekke om brukeren skal få egen start side som sier at de ikke kan bruke kalkulatoren for å beregne Alders pensjon er endret fra 75 år til måneden bruker fyller 75 år + 1 måned
eks. bruker født 1. april og bruker født 30. april skal begge kom inn i kalkulatoren t.o.m. april. Fra 1.mai får de start side som informerer at de ikke kan bruke kalkulatoren