### PR TITLE
Mocking av api state uten await

### DIFF
--- a/src/components/AvansertSkjema/AvansertSkjemaForAndreBrukere/__tests__/AvansertSkjemaForAndreBrukere.test.tsx
+++ b/src/components/AvansertSkjema/AvansertSkjemaForAndreBrukere/__tests__/AvansertSkjemaForAndreBrukere.test.tsx
@@ -48,7 +48,7 @@ describe('AvansertSkjemaForAndreBrukere', () => {
   const agePickerMonth = getPreviousMonth()
 
   it('vises informasjon om inntekt, uttaksgrad og pensjonsalder', async () => {
-    await render(
+    render(
       <BeregningContext.Provider
         value={{
           ...contextMockedValues,
@@ -273,7 +273,7 @@ describe('AvansertSkjemaForAndreBrukere', () => {
 
   it('Når alle feltene fylles ut og resetForm kalles, nullstilles alle feltene', async () => {
     const user = userEvent.setup()
-    const { store } = await render(
+    const { store } = render(
       <BeregningContext.Provider
         value={{
           ...contextMockedValues,
@@ -541,7 +541,7 @@ describe('AvansertSkjemaForAndreBrukere', () => {
 
   it('Når alle feltene for 100 % uttak fylles ut og radioknappen for inntekt endres til nei, skjules inntekt og sluttAlder', async () => {
     const user = userEvent.setup()
-    const { store } = await render(
+    const { store } = render(
       <BeregningContext.Provider
         value={{
           ...contextMockedValues,
@@ -631,7 +631,7 @@ describe('AvansertSkjemaForAndreBrukere', () => {
 
   it('Når alle feltene for gradert uttak fylles ut og radioknappen for inntekt endres til nei, skjules inputfeltet for inntekt', async () => {
     const user = userEvent.setup()
-    const { store } = await render(
+    const { store } = render(
       <BeregningContext.Provider
         value={{
           ...contextMockedValues,
@@ -752,7 +752,7 @@ describe('AvansertSkjemaForAndreBrukere', () => {
 
   it('Når feltene for 100 % uttak fylles ut og uttaksalder endres til en alder større enn sluttAlder for inntekt, nullstilles sluttAlder', async () => {
     const user = userEvent.setup()
-    const { store } = await render(
+    const { store } = render(
       <BeregningContext.Provider
         value={{
           ...contextMockedValues,
@@ -1440,7 +1440,7 @@ describe('AvansertSkjemaForAndreBrukere', () => {
 
   describe('Når en bruker som mottar 100 % uføretrygd legger inn et gradert uttak, ', () => {
     it('vises informasjon om pensjonsalder og uføretrygd, og aldersvelgere begrenses fra normert pensjonsalder', async () => {
-      const { store } = await render(
+      const { store } = render(
         <BeregningContext.Provider
           value={{
             ...contextMockedValues,
@@ -1816,7 +1816,7 @@ describe('AvansertSkjemaForAndreBrukere', () => {
     })
 
     it('vises det riktig label på feltene', async () => {
-      const { store } = await render(
+      const { store } = render(
         <BeregningContext.Provider
           value={{
             ...contextMockedValues,
@@ -1871,7 +1871,7 @@ describe('AvansertSkjemaForAndreBrukere', () => {
     })
 
     it('Når brukeren har 100 % uføretrygd, vises riktig tekst i readmore om uttaksgrad', async () => {
-      const { store } = await render(
+      const { store } = render(
         <BeregningContext.Provider
           value={{
             ...contextMockedValues,

--- a/src/components/AvansertSkjema/AvansertSkjemaForBrukereMedGradertUfoeretrygd/Beregningsvalg/__tests__/Beregningsvalg.test.tsx
+++ b/src/components/AvansertSkjema/AvansertSkjemaForBrukereMedGradertUfoeretrygd/Beregningsvalg/__tests__/Beregningsvalg.test.tsx
@@ -82,8 +82,8 @@ describe('Beregningsvalg', () => {
       expect(medAfpRadio).toBeChecked()
     })
 
-    it('Håndterer nullstilling korrekt', async () => {
-      const { rerender } = await renderWithDefaultState({
+    it('Håndterer nullstilling korrekt', () => {
+      const { rerender } = renderWithDefaultState({
         localBeregningsTypeRadio: 'med_afp',
       })
       expect(screen.getByTestId('med_afp')).toBeChecked()

--- a/src/components/AvansertSkjema/AvansertSkjemaForBrukereMedGradertUfoeretrygd/__tests__/AvansertSkjemaForBrukereMedGradertUfoeretrygd.test.tsx
+++ b/src/components/AvansertSkjema/AvansertSkjemaForBrukereMedGradertUfoeretrygd/__tests__/AvansertSkjemaForBrukereMedGradertUfoeretrygd.test.tsx
@@ -324,7 +324,7 @@ describe('AvansertSkjemaForBrukereMedGradertUfoeretrygd', () => {
 
   it('Når alle feltene fylles ut og resetForm kalles, nullstilles alle feltene', async () => {
     const user = userEvent.setup()
-    const { store } = await render(
+    const { store } = render(
       <BeregningContext.Provider
         value={{
           ...contextMockedValues,
@@ -592,7 +592,7 @@ describe('AvansertSkjemaForBrukereMedGradertUfoeretrygd', () => {
 
   it('Når alle feltene for 100 % uttak fylles ut og radioknappen for inntekt endres til nei, skjules inntekt og sluttAlder', async () => {
     const user = userEvent.setup()
-    const { store } = await render(
+    const { store } = render(
       <BeregningContext.Provider
         value={{
           ...contextMockedValues,
@@ -682,7 +682,7 @@ describe('AvansertSkjemaForBrukereMedGradertUfoeretrygd', () => {
 
   it('Når alle feltene for gradert uttak fylles ut og radioknappen for inntekt endres til nei, skjules inputfeltet for inntekt', async () => {
     const user = userEvent.setup()
-    const { store } = await render(
+    const { store } = render(
       <BeregningContext.Provider
         value={{
           ...contextMockedValues,
@@ -803,7 +803,7 @@ describe('AvansertSkjemaForBrukereMedGradertUfoeretrygd', () => {
 
   it('Når feltene for 100 % uttak fylles ut og uttaksalder endres til en alder større enn sluttAlder for inntekt, nullstilles sluttAlder', async () => {
     const user = userEvent.setup()
-    const { store } = await render(
+    const { store } = render(
       <BeregningContext.Provider
         value={{
           ...contextMockedValues,

--- a/src/components/AvansertSkjema/__tests__/AvansertSkjema-hooks.test.tsx
+++ b/src/components/AvansertSkjema/__tests__/AvansertSkjema-hooks.test.tsx
@@ -946,7 +946,7 @@ describe('AvansertSkjema-hooks', () => {
       })
 
       // gradertAgePickerError
-      const gradertAgePickerError = await render(
+      const gradertAgePickerError = render(
         result.current[1] as React.ReactElement
       )
       expect(gradertAgePickerError.asFragment()).toMatchInlineSnapshot(`
@@ -962,9 +962,7 @@ describe('AvansertSkjema-hooks', () => {
       `)
 
       // heltAgePickerError
-      const heltAgePickerError = await render(
-        result.current[2] as React.ReactElement
-      )
+      const heltAgePickerError = render(result.current[2] as React.ReactElement)
       expect(heltAgePickerError.asFragment()).toMatchInlineSnapshot(`
         <DocumentFragment>
           id4

--- a/src/components/EndreInntekt/InfoOmInntekt/__tests__/InfoOmInntekt.test.tsx
+++ b/src/components/EndreInntekt/InfoOmInntekt/__tests__/InfoOmInntekt.test.tsx
@@ -4,7 +4,7 @@ import { InfoOmInntekt } from '..'
 
 describe('InfoModalInntekt', () => {
   it('viser fast info om inntekt', async () => {
-    const { getByTestId } = await render(<InfoOmInntekt />)
+    const { getByTestId } = render(<InfoOmInntekt />)
 
     // Check for lists
     const infoList = getByTestId('info-om-inntekt-list')

--- a/src/components/EndreInntekt/__tests__/EndreInntekt.test.tsx
+++ b/src/components/EndreInntekt/__tests__/EndreInntekt.test.tsx
@@ -154,7 +154,7 @@ describe('EndreInntekt', () => {
           ufoeretrygd: { grad: 100 },
         } satisfies LoependeVedtak,
       })
-      const { store } = await render(
+      const { store } = render(
         <EndreInntekt visning="enkel" value="123" onSubmit={vi.fn()} />
       )
       await store.dispatch(apiSlice.endpoints.getLoependeVedtak.initiate())

--- a/src/components/Grunnlag/GrunnlagAFP/__tests__/GrunnlagAFP.test.tsx
+++ b/src/components/Grunnlag/GrunnlagAFP/__tests__/GrunnlagAFP.test.tsx
@@ -216,7 +216,7 @@ describe('Grunnlag - AFP', () => {
       }
 
       it('returneres null', async () => {
-        const { asFragment } = await render(<GrunnlagAFP />, {
+        const { asFragment } = render(<GrunnlagAFP />, {
           preloadedState: {
             api: {
               // @ts-ignore

--- a/src/components/Grunnlag/GrunnlagInntekt/__tests__/GrunnlagInntekt.test.tsx
+++ b/src/components/Grunnlag/GrunnlagInntekt/__tests__/GrunnlagInntekt.test.tsx
@@ -18,7 +18,7 @@ describe('GrunnlagInntekt', () => {
   describe('Gitt at brukeren har inntekt hentet fra Skatteetaten', () => {
     const user = userEvent.setup()
     beforeEach(async () => {
-      const { store } = await render(
+      const { store } = render(
         <WrappedGrunnlagInntekt goToAvansert={vi.fn()} />
       )
       store.dispatch(apiSlice.endpoints.getInntekt.initiate())
@@ -84,7 +84,7 @@ describe('GrunnlagInntekt', () => {
         status: 200,
         json: { aar: 2021, beloep: 0 },
       })
-      const { store } = await render(
+      const { store } = render(
         <WrappedGrunnlagInntekt goToAvansert={vi.fn()} />
       )
       await store.dispatch(apiSlice.endpoints.getInntekt.initiate())

--- a/src/components/InfoOmFremtidigVedtak/__tests__/InfoOmFremtidigVedtak.test.tsx
+++ b/src/components/InfoOmFremtidigVedtak/__tests__/InfoOmFremtidigVedtak.test.tsx
@@ -11,7 +11,7 @@ import { InfoOmFremtidigVedtak } from '..'
 
 describe('InfoOmFremtidigVedtak', () => {
   it('Ved gjeldende vedtak uten fremtidig vedtak, returnerer null', async () => {
-    const { asFragment } = await render(
+    const { asFragment } = render(
       <InfoOmFremtidigVedtak
         loependeVedtak={
           fulfilledGetLoependeVedtakLoependeAlderspensjon[
@@ -24,7 +24,7 @@ describe('InfoOmFremtidigVedtak', () => {
   })
 
   it('Ved både gjeldende og fremtidig vedtak, returnerer null', async () => {
-    const { asFragment } = await render(
+    const { asFragment } = render(
       <InfoOmFremtidigVedtak
         loependeVedtak={
           fulfilledGetLoependeVedtakFremtidigMedAlderspensjon[

--- a/src/components/InfoOmLoependeVedtak/__tests__/InfoOmLoependeVedtak.test.tsx
+++ b/src/components/InfoOmLoependeVedtak/__tests__/InfoOmLoependeVedtak.test.tsx
@@ -12,12 +12,12 @@ import { InfoOmLoependeVedtak } from '..'
 
 describe('InfoOmLoependeVedtak', () => {
   it('Når vedtaket ikke er oppgitt, returnerer null', async () => {
-    const { asFragment } = await render(<InfoOmLoependeVedtak />)
+    const { asFragment } = render(<InfoOmLoependeVedtak />)
     expect(asFragment()).toMatchInlineSnapshot(`<DocumentFragment />`)
   })
 
   it('Når vedtaket ikke gjelder alderspensjon, returnerer null', async () => {
-    const { asFragment } = await render(
+    const { asFragment } = render(
       <InfoOmLoependeVedtak
         loependeVedtak={
           fulfilledGetLoependeVedtak75Ufoeregrad['getLoependeVedtak(undefined)']

--- a/src/components/LightBlueFooter/__tests__/LightBlueFooter.test.tsx
+++ b/src/components/LightBlueFooter/__tests__/LightBlueFooter.test.tsx
@@ -25,7 +25,7 @@ describe('LightBlueFooter', () => {
     it('Når brukeren bekrefter, nullstiller input fra brukeren og redirigerer til første steg av stegvisning', async () => {
       const user = userEvent.setup()
 
-      const { store } = await render(<LightBlueFooter />, {
+      const { store } = render(<LightBlueFooter />, {
         preloadedState: {
           userInput: { ...userInputInitialState, samtykke: true },
         },

--- a/src/components/Pensjonsavtaler/OffentligTjenestePensjon/__tests__/OffentligTjenestepensjon.test.tsx
+++ b/src/components/Pensjonsavtaler/OffentligTjenestePensjon/__tests__/OffentligTjenestepensjon.test.tsx
@@ -139,7 +139,7 @@ describe('OffentligTjenestepensjon', () => {
     it('Når simuleringen er vellykket og brukeren er på desktop, viser riktig informasjon og liste over offentlige avtaler.', async () => {
       vi.spyOn(useIsMobileUtils, 'useIsMobile').mockReturnValue(false)
 
-      const { container } = await render(
+      const { container } = render(
         <OffentligTjenestepensjon
           isLoading={false}
           isError={false}
@@ -199,7 +199,7 @@ describe('OffentligTjenestepensjon', () => {
 
     it('Når simuleringen er vellykket og brukeren er på mobil, viser riktig informasjon og liste over offentlige avtaler.', async () => {
       vi.spyOn(useIsMobileUtils, 'useIsMobile').mockReturnValue(true)
-      const { container } = await render(
+      const { container } = render(
         <OffentligTjenestepensjon
           isLoading={false}
           isError={false}

--- a/src/components/Pensjonsavtaler/PrivatePensjonsavtaler/__tests__/PrivatePensjonsavtalerDesktop.test.tsx
+++ b/src/components/Pensjonsavtaler/PrivatePensjonsavtaler/__tests__/PrivatePensjonsavtalerDesktop.test.tsx
@@ -47,7 +47,7 @@ describe('PrivatePensjonsavtalerDesktop', () => {
   })
 
   it('rendrer riktig med avtaler som bare har start dato', async () => {
-    const { container } = await render(
+    const { container } = render(
       <PrivatePensjonsavtalerDesktop
         headingLevel="4"
         pensjonsavtaler={avtaler}
@@ -103,7 +103,7 @@ describe('PrivatePensjonsavtalerDesktop', () => {
       ],
     }
 
-    const { container } = await render(
+    const { container } = render(
       <PrivatePensjonsavtalerDesktop
         headingLevel="4"
         pensjonsavtaler={[avtaleMedStartOgSlutt]}

--- a/src/components/Pensjonsavtaler/PrivatePensjonsavtaler/__tests__/PrivatePensjonsavtalerMobile.test.tsx
+++ b/src/components/Pensjonsavtaler/PrivatePensjonsavtaler/__tests__/PrivatePensjonsavtalerMobile.test.tsx
@@ -44,7 +44,7 @@ describe('PrivatePensjonsavtalerMobile', () => {
   })
 
   it('rendrer riktig med avtaler som bare har start dato', async () => {
-    const { container } = await render(
+    const { container } = render(
       <PrivatePensjonsavtalerMobile
         headingLevel="4"
         pensjonsavtaler={avtaler}
@@ -92,7 +92,7 @@ describe('PrivatePensjonsavtalerMobile', () => {
       ],
     }
 
-    const { container } = await render(
+    const { container } = render(
       <PrivatePensjonsavtalerMobile
         headingLevel="4"
         pensjonsavtaler={[avtaleMedStartOgSlutt]}

--- a/src/components/Pensjonsavtaler/__tests__/Pensjonsavtaler.test.tsx
+++ b/src/components/Pensjonsavtaler/__tests__/Pensjonsavtaler.test.tsx
@@ -43,7 +43,7 @@ describe('Pensjonsavtaler', () => {
     it('viser riktig header og melding med lenke tilbake til start, og skjuler ingress, tabell og info om offentlig tjenestepensjon.', async () => {
       const user = userEvent.setup()
 
-      const { store } = await render(<Pensjonsavtaler headingLevel="3" />, {
+      const { store } = render(<Pensjonsavtaler headingLevel="3" />, {
         preloadedState: {
           api: {
             // @ts-ignore

--- a/src/components/SavnerDuNoe/__tests__/SavnerDuNoe.test.tsx
+++ b/src/components/SavnerDuNoe/__tests__/SavnerDuNoe.test.tsx
@@ -48,7 +48,7 @@ describe('SavnerDuNoe', () => {
     it('nullstiller input fra brukeren og redirigerer til avansert beregning når brukeren klikker på knappen', async () => {
       const user = userEvent.setup()
 
-      const { store } = await render(
+      const { store } = render(
         <SavnerDuNoe headingLevel="2" isEndring={false} showAvansert />,
         {
           preloadedState: {

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/__tests__/PensjonVisningDesktop.test.tsx
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/__tests__/PensjonVisningDesktop.test.tsx
@@ -59,7 +59,7 @@ describe('DesktopPensjonVisning', () => {
   })
 
   it('returnerer null når ingen pensjonsdata oppføringer er tilgjengelige', async () => {
-    const { container } = await render(
+    const { container } = render(
       <PensjonVisningDesktop
         pensjonsdata={[]}
         summerYtelser={mockSummerYtelser}

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/__tests__/PensjonVisningMobil.test.tsx
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/__tests__/PensjonVisningMobil.test.tsx
@@ -52,7 +52,7 @@ describe('MobilePensjonVisning', () => {
   })
 
   it('returnerer null når ingen pensjonsdata er tilgjengelig', async () => {
-    const { container } = await render(
+    const { container } = render(
       <PensjonVisningMobil
         pensjonsdata={[]}
         summerYtelser={mockSummerYtelser}

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/__tests__/MaanedsbeloepAvansertBeregning.test.tsx
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/__tests__/MaanedsbeloepAvansertBeregning.test.tsx
@@ -86,7 +86,7 @@ describe('MaanedsbeloepAvansertBeregning', () => {
   })
 
   it('returnerer null når uttaksalder ikke er definert', async () => {
-    const { container } = await render(
+    const { container } = render(
       <MaanedsbeloepAvansertBeregning
         alderspensjonMaanedligVedEndring={{
           heltUttakMaanedligBeloep: 20000,

--- a/src/components/Simulering/SimuleringEndringBanner/__tests__/SimuleringEndringBanner.test.tsx
+++ b/src/components/Simulering/SimuleringEndringBanner/__tests__/SimuleringEndringBanner.test.tsx
@@ -40,7 +40,7 @@ describe('SimuleringEndringBanner', () => {
     })
 
     it('Når heltUttaksalder er satt, skal banneren vises med riktig tekst.', async () => {
-      const { asFragment } = await render(
+      const { asFragment } = render(
         <SimuleringEndringBanner
           isLoading={false}
           heltUttaksalder={{ aar: 67, maaneder: 0 }}
@@ -98,7 +98,7 @@ describe('SimuleringEndringBanner', () => {
     })
 
     it('Når heltUttaksalder er satt med alderspensjonMaanedligVedEndring, skal banneren vises med riktig tekst.', async () => {
-      const { asFragment } = await render(
+      const { asFragment } = render(
         <SimuleringEndringBanner
           isLoading={false}
           heltUttaksalder={{ aar: 67, maaneder: 0 }}
@@ -159,7 +159,7 @@ describe('SimuleringEndringBanner', () => {
     })
 
     it('Når heltUttaksalder og gradertUttaksperiode er satt, skal banneren vises med riktig tekst.', async () => {
-      const { asFragment } = await render(
+      const { asFragment } = render(
         <SimuleringEndringBanner
           isLoading={false}
           heltUttaksalder={{ aar: 67, maaneder: 0 }}

--- a/src/components/Simulering/Simuleringsdetaljer/__tests__/Simuleringsdetaljer.test.tsx
+++ b/src/components/Simulering/Simuleringsdetaljer/__tests__/Simuleringsdetaljer.test.tsx
@@ -35,7 +35,7 @@ describe('Simuleringsdetaljer', () => {
       { aar: 2020, pensjonsgivendeInntektBeloep: 500000 },
       { aar: 2021, pensjonsgivendeInntektBeloep: 550000 },
     ]
-    const { asFragment } = await render(
+    const { asFragment } = render(
       <Simuleringsdetaljer detaljer={{ opptjeningsgrunnlag }} />
     )
     expect(asFragment()).toMatchInlineSnapshot(`
@@ -165,7 +165,7 @@ describe('Simuleringsdetaljer', () => {
         skjermingstillegg: 0,
       },
     ]
-    const { asFragment } = await render(
+    const { asFragment } = render(
       <Simuleringsdetaljer
         alderspensjonListe={alderspensjonListe}
         detaljer={{}}
@@ -363,7 +363,7 @@ describe('Simuleringsdetaljer', () => {
         skjermingstillegg: undefined,
       },
     ]
-    const { asFragment } = await render(
+    const { asFragment } = render(
       <Simuleringsdetaljer
         alderspensjonListe={alderspensjonListe}
         detaljer={{}}

--- a/src/components/Simulering/__tests__/Simulering.test.tsx
+++ b/src/components/Simulering/__tests__/Simulering.test.tsx
@@ -53,7 +53,7 @@ describe('Simulering', () => {
   })
 
   it('Når alderspensjon laster så vises det en spinner, og deretter heading på riktig nivå', async () => {
-    const { container } = await render(
+    const { container } = render(
       <Simulering
         isLoading={true}
         headingLevel="3"
@@ -146,7 +146,7 @@ describe('Simulering', () => {
         apiSliceUtils,
         'usePensjonsavtalerQuery'
       )
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"
@@ -194,7 +194,7 @@ describe('Simulering', () => {
     })
 
     it('Når brukeren velger AFP-privat, viser inntekt, alderspensjon og AFP', async () => {
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"
@@ -241,7 +241,7 @@ describe('Simulering', () => {
     })
 
     it('Når brukeren velger AFP-offentlig, viser inntekt, alderspensjon og AFP', async () => {
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"
@@ -288,7 +288,7 @@ describe('Simulering', () => {
     })
 
     it('Når brukeren velger uttaksagrad 67 år, vises årene i grafen fra 66 år til 77+', async () => {
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"
@@ -329,7 +329,7 @@ describe('Simulering', () => {
     })
 
     it('Når brukeren velger gradert pensjon med uttaksgrad 62 år, vises årene i grafen fra 61 år til 77+', async () => {
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"
@@ -407,7 +407,7 @@ describe('Simulering', () => {
         apiSliceUtils,
         'usePensjonsavtalerQuery'
       )
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"
@@ -483,7 +483,7 @@ describe('Simulering', () => {
         apiSliceUtils,
         'usePensjonsavtalerQuery'
       )
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"
@@ -550,7 +550,7 @@ describe('Simulering', () => {
         apiSliceUtils,
         'usePensjonsavtalerQuery'
       )
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"
@@ -616,7 +616,7 @@ describe('Simulering', () => {
         apiSliceUtils,
         'usePensjonsavtalerQuery'
       )
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"
@@ -694,7 +694,7 @@ describe('Simulering', () => {
         apiSliceUtils,
         'usePensjonsavtalerQuery'
       )
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"
@@ -785,7 +785,7 @@ describe('Simulering', () => {
         method: 'post',
       })
 
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"
@@ -840,7 +840,7 @@ describe('Simulering', () => {
         method: 'post',
       })
 
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"
@@ -916,7 +916,7 @@ describe('Simulering', () => {
         method: 'post',
       })
 
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"
@@ -986,7 +986,7 @@ describe('Simulering', () => {
         method: 'post',
       })
 
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"
@@ -1044,7 +1044,7 @@ describe('Simulering', () => {
         method: 'post',
       })
 
-      const { container } = await render(
+      const { container } = render(
         <Simulering
           isLoading={false}
           headingLevel="3"

--- a/src/components/VelgUttaksalder/__tests__/VelgUttaksalder.test.tsx
+++ b/src/components/VelgUttaksalder/__tests__/VelgUttaksalder.test.tsx
@@ -40,7 +40,7 @@ describe('VelgUttaksalder', () => {
       tidligstMuligUttak: uttaksalder,
     })
 
-    const { rerender } = await render(<VelgUttaksalder {...getProps()} />, {
+    const { rerender } = render(<VelgUttaksalder {...getProps()} />, {
       // @ts-ignore
       preloadedState: {
         ...mockedState,

--- a/src/components/common/AgePicker/__tests__/AgePicker.test.tsx
+++ b/src/components/common/AgePicker/__tests__/AgePicker.test.tsx
@@ -8,7 +8,7 @@ import { AgePicker } from '..'
 
 describe('AgePicker', () => {
   it('rendrer riktig default verdier, description og info', async () => {
-    const { container } = await render(
+    const { container } = render(
       <AgePicker
         name="unique-name"
         label="My Test Age Picker"
@@ -29,7 +29,7 @@ describe('AgePicker', () => {
 
   describe('rendrer riktig valg i select', () => {
     it('med default min og max', async () => {
-      const { container } = await render(
+      const { container } = render(
         <AgePicker name="unique-name" label="My Test Age Picker" />,
         {
           preloadedState: {
@@ -76,7 +76,7 @@ describe('AgePicker', () => {
     })
 
     it('med custom min og max', async () => {
-      const { container } = await render(
+      const { container } = render(
         <AgePicker
           name="unique-name"
           label="My Test Age Picker"
@@ -128,7 +128,7 @@ describe('AgePicker', () => {
 
     describe('Når min/maxAlder er oppgitt og år er valgt', () => {
       it('viser bare månedene som kan velges basert mellom min og max mellom to år', async () => {
-        const { container } = await render(
+        const { container } = render(
           <AgePicker
             name="unique-name"
             label="My Test Age Picker"
@@ -170,7 +170,7 @@ describe('AgePicker', () => {
       })
 
       it('viser bare månedene som kan velges basert mellom min og max innen samme år', async () => {
-        const { container } = await render(
+        const { container } = render(
           <AgePicker
             name="unique-name"
             label="My Test Age Picker"
@@ -285,7 +285,7 @@ describe('AgePicker', () => {
 
   it('kaller onChange når option velges i år eller måneder, og Select for måneder enables når år er valgt', async () => {
     const onChangeMock = vi.fn()
-    const { container } = await render(
+    const { container } = render(
       <AgePicker
         name="unique-name"
         label="My Test Age Picker"

--- a/src/components/common/Card/__tests__/Card.test.tsx
+++ b/src/components/common/Card/__tests__/Card.test.tsx
@@ -7,7 +7,7 @@ import { Card } from '..'
 describe('Card', () => {
   it('viser innhold korrekt uten className', async () => {
     const testContent = 'lorem ipsum'
-    const { getByText } = await render(
+    const { getByText } = render(
       <Card>
         <p>{testContent}</p>
       </Card>
@@ -17,7 +17,7 @@ describe('Card', () => {
 
   it('bruker egendefinert className når det er gitt', async () => {
     const customClass = 'className'
-    const { container } = await render(
+    const { container } = render(
       <Card className={customClass}>
         <p>lorem ipsum</p>
       </Card>
@@ -27,7 +27,7 @@ describe('Card', () => {
   })
 
   it('bruker stor padding når hasLargePadding er satt til true', async () => {
-    const { container } = await render(
+    const { container } = render(
       <Card hasLargePadding>
         <p>lorem ipsum</p>
       </Card>
@@ -37,7 +37,7 @@ describe('Card', () => {
   })
 
   it('bruker margin når hasMargin er satt til true', async () => {
-    const { container } = await render(
+    const { container } = render(
       <Card hasMargin>
         <p>lorem ipsum</p>
       </Card>
@@ -48,7 +48,7 @@ describe('Card', () => {
 
   it('kombinerer alle props korrekt', async () => {
     const customClass = 'customClassName'
-    const { container } = await render(
+    const { container } = render(
       <Card className={customClass} hasLargePadding hasMargin>
         <p>lorem ipsum</p>
       </Card>

--- a/src/components/common/Divider/__tests__/Divider.test.tsx
+++ b/src/components/common/Divider/__tests__/Divider.test.tsx
@@ -6,7 +6,7 @@ import { Divider } from '..'
 
 describe('Divider', () => {
   it('viser korrekt med standardverdier', async () => {
-    const { container } = await render(<Divider />)
+    const { container } = render(<Divider />)
     const divider = container.querySelector('hr')
     expect(divider).toBeInTheDocument()
     expect(divider?.className).toMatch(/divider_[a-zA-Z0-9]+/)
@@ -16,21 +16,21 @@ describe('Divider', () => {
   })
 
   it('viser korrekt uten margin', async () => {
-    const { container } = await render(<Divider noMargin />)
+    const { container } = render(<Divider noMargin />)
     const divider = container.querySelector('hr')
     expect(divider).toBeInTheDocument()
     expect(divider?.className).toContain('noMargin')
   })
 
   it('viser korrekt med liten margin', async () => {
-    const { container } = await render(<Divider smallMargin />)
+    const { container } = render(<Divider smallMargin />)
     const divider = container.querySelector('hr')
     expect(divider).toBeInTheDocument()
     expect(divider?.className).toContain('smallMargin')
   })
 
   it('viser korrekt uten margin i bunnen', async () => {
-    const { container } = await render(<Divider noMarginBottom />)
+    const { container } = render(<Divider noMarginBottom />)
     const divider = container.querySelector('hr')
     expect(divider).toBeInTheDocument()
     expect(divider?.className).toContain('noMarginBottom')

--- a/src/components/common/SanityReadmore/__tests__/SanityReadmore.test.tsx
+++ b/src/components/common/SanityReadmore/__tests__/SanityReadmore.test.tsx
@@ -17,13 +17,9 @@ describe('SanityReadmore', () => {
     expect(screen.getByText('Lorem')).toBeInTheDocument()
   })
 
-  it('kaster runtime error når id ikke finnes i readMoreData', async () => {
-    let error
-    try {
-      await render(<SanityReadmore id="non-existent-id" />)
-    } catch (err) {
-      error = err
-    }
-    expect(error).toBeInstanceOf(Error)
+  it('kaster runtime error når id ikke finnes i readMoreData', () => {
+    expect(() => {
+      render(<SanityReadmore id="non-existent-id" />)
+    }).toThrow()
   })
 })

--- a/src/components/stegvisning/Utenlandsopphold/__tests__/Utenlandsopphold.test.tsx
+++ b/src/components/stegvisning/Utenlandsopphold/__tests__/Utenlandsopphold.test.tsx
@@ -205,7 +205,7 @@ describe('stegvisning - Utenlandsopphold', () => {
 
     it('viser valideringsteksten i bunnen når harUtenlandsopphold er true og at brukeren ikke har registrert utenlandsperioder, og skjuler den når brukeren legger til en periode', async () => {
       const user = userEvent.setup()
-      const { store } = await render(
+      const { store } = render(
         <Utenlandsopphold
           harUtenlandsopphold={true}
           onCancel={onCancelMock}

--- a/src/pages/Beregning/__tests__/BeregningAvansert.test.tsx
+++ b/src/pages/Beregning/__tests__/BeregningAvansert.test.tsx
@@ -474,7 +474,7 @@ describe('BeregningAvansert', () => {
           'initiate'
         )
 
-        const { container } = await render(
+        const { container } = render(
           <BeregningContext.Provider
             value={{
               ...contextMockedValues,
@@ -702,7 +702,7 @@ describe('BeregningAvansert', () => {
         'initiate'
       )
 
-      const { container } = await render(
+      const { container } = render(
         <BeregningContext.Provider
           value={{
             ...contextMockedValues,
@@ -777,7 +777,7 @@ describe('BeregningAvansert', () => {
         'initiate'
       )
 
-      const { container } = await render(
+      const { container } = render(
         <BeregningContext.Provider
           value={{
             ...contextMockedValues,

--- a/src/pages/Beregning/__tests__/BeregningEnkel.test.tsx
+++ b/src/pages/Beregning/__tests__/BeregningEnkel.test.tsx
@@ -290,7 +290,7 @@ describe('BeregningEnkel', () => {
   describe('Når brukeren velger uttaksalder', () => {
     it('viser en loader mens beregning av alderspensjon pågår, oppdaterer valgt knapp og tegner graph og viser tabell, Pensjonsavtaler, Grunnlag og Forbehold, gitt at beregning av alderspensjon var vellykket', async () => {
       const user = userEvent.setup()
-      const { container } = await render(<BeregningEnkel />, {
+      const { container } = render(<BeregningEnkel />, {
         preloadedState: {
           api: {
             // @ts-ignore
@@ -336,7 +336,7 @@ describe('BeregningEnkel', () => {
         'initiate'
       )
       const user = userEvent.setup()
-      const { store } = await render(<BeregningEnkel />, {
+      const { store } = render(<BeregningEnkel />, {
         preloadedState: {
           api: {
             // @ts-ignore
@@ -428,7 +428,7 @@ describe('BeregningEnkel', () => {
         'initiate'
       )
       const user = userEvent.setup()
-      const { store } = await render(<BeregningEnkel />, {
+      const { store } = render(<BeregningEnkel />, {
         preloadedState: {
           api: {
             // @ts-ignore
@@ -521,7 +521,7 @@ describe('BeregningEnkel', () => {
       )
 
       const user = userEvent.setup()
-      const { store } = await render(<BeregningEnkel />, {
+      const { store } = render(<BeregningEnkel />, {
         preloadedState: {
           api: {
             // @ts-ignore
@@ -613,7 +613,7 @@ describe('BeregningEnkel', () => {
       )
 
       const user = userEvent.setup()
-      const { store } = await render(<BeregningEnkel />, {
+      const { store } = render(<BeregningEnkel />, {
         preloadedState: {
           api: {
             // @ts-ignore
@@ -910,7 +910,7 @@ describe('BeregningEnkel', () => {
   describe('Gitt at brukeren har vedtak om alderspensjon,', () => {
     it('viser en loader mens beregning av alderspensjon pågår, oppdaterer valgt knapp og tegner graph og viser tabell, Pensjonsavtaler, Grunnlag og Forbehold, gitt at beregning av alderspensjon var vellykket', async () => {
       const user = userEvent.setup()
-      const { container } = await render(<BeregningEnkel />, {
+      const { container } = render(<BeregningEnkel />, {
         preloadedState: {
           api: {
             // @ts-ignore
@@ -961,7 +961,7 @@ describe('BeregningEnkel', () => {
       )
 
       const user = userEvent.setup()
-      const { store } = await render(<BeregningEnkel />, {
+      const { store } = render(<BeregningEnkel />, {
         preloadedState: {
           api: {
             // @ts-ignore

--- a/src/pages/StepFeil/__tests__/StepFeil.test.tsx
+++ b/src/pages/StepFeil/__tests__/StepFeil.test.tsx
@@ -33,7 +33,7 @@ describe('Step Feil', () => {
   it('redirigerer til landingssiden når brukeren klikker på knappen', async () => {
     const user = userEvent.setup()
 
-    const { store } = await render(<StepFeil />, {
+    const { store } = render(<StepFeil />, {
       preloadedState: {
         userInput: {
           ...userInputInitialState,

--- a/src/pages/StepSamtykkeOffentligAFP/__tests__/StepSamtykkeOffentligAFP.test.tsx
+++ b/src/pages/StepSamtykkeOffentligAFP/__tests__/StepSamtykkeOffentligAFP.test.tsx
@@ -28,7 +28,7 @@ describe('StepSamtykkeOffentligAFP', () => {
     it('registrerer samtykke og navigerer videre til riktig side når brukeren klikker på Neste', async () => {
       const user = userEvent.setup()
 
-      const { store } = await render(<StepSamtykkeOffentligAFP />, {
+      const { store } = render(<StepSamtykkeOffentligAFP />, {
         preloadedState: {
           api: {
             // @ts-ignore
@@ -52,7 +52,7 @@ describe('StepSamtykkeOffentligAFP', () => {
     it('registrerer samtykke og navigerer videre til riktig side når brukeren klikker på Neste', async () => {
       const user = userEvent.setup()
 
-      const { store } = await render(<StepSamtykkeOffentligAFP />, {
+      const { store } = render(<StepSamtykkeOffentligAFP />, {
         preloadedState: {
           api: {
             // @ts-ignore

--- a/src/pages/StepSamtykkePensjonsavtaler/__tests__/StepSamtykkePensjonsavtaler.test.tsx
+++ b/src/pages/StepSamtykkePensjonsavtaler/__tests__/StepSamtykkePensjonsavtaler.test.tsx
@@ -33,7 +33,7 @@ describe('StepSamtykkePensjonsavtaler', () => {
     it('registrerer samtykke og navigerer videre til riktig side når brukeren klikker på Neste', async () => {
       const user = userEvent.setup()
 
-      const { store } = await render(<StepSamtykkePensjonsavtaler />, {
+      const { store } = render(<StepSamtykkePensjonsavtaler />, {
         preloadedState: {
           api: {
             // @ts-ignore
@@ -63,7 +63,7 @@ describe('StepSamtykkePensjonsavtaler', () => {
 
       const user = userEvent.setup()
 
-      const { store } = await render(<StepSamtykkePensjonsavtaler />, {
+      const { store } = render(<StepSamtykkePensjonsavtaler />, {
         preloadedState: {
           api: {
             // @ts-ignore

--- a/src/pages/StepUtenlandsopphold/__tests__/StepUtenlandsopphold.test.tsx
+++ b/src/pages/StepUtenlandsopphold/__tests__/StepUtenlandsopphold.test.tsx
@@ -29,7 +29,7 @@ describe('StepUtenlandsopphold', () => {
   it('Når brukeren svarer ja på utenlandsopphold, registreres det svaret og brukeren kan gå til neste steg når hen klikker på Neste', async () => {
     const user = userEvent.setup()
 
-    const { store } = await render(<StepUtenlandsopphold />, {
+    const { store } = render(<StepUtenlandsopphold />, {
       preloadedState: {
         api: {
           // @ts-ignore
@@ -52,7 +52,7 @@ describe('StepUtenlandsopphold', () => {
   it('Når brukeren svarer nei på utenlandsopphold, registreres det svaret, slettes utenlandsoppholdene og brukeren er sendt videre til riktig side når hen klikker på Neste', async () => {
     const user = userEvent.setup()
 
-    const { store } = await render(<StepUtenlandsopphold />, {
+    const { store } = render(<StepUtenlandsopphold />, {
       preloadedState: {
         api: {
           // @ts-ignore
@@ -112,7 +112,7 @@ describe('StepUtenlandsopphold', () => {
 
     const user = userEvent.setup()
 
-    const { store } = await render(<StepUtenlandsopphold />, {
+    const { store } = render(<StepUtenlandsopphold />, {
       preloadedState: {
         userInput: { ...userInputInitialState, harUtenlandsopphold: null },
       },

--- a/src/pages/VeilederInput/__tests__/VeilederInputRequestError.test.tsx
+++ b/src/pages/VeilederInput/__tests__/VeilederInputRequestError.test.tsx
@@ -41,7 +41,7 @@ describe('veileder - feilmeldinger', () => {
   })
 
   it('Ingen feil', async () => {
-    const { container } = await render(
+    const { container } = render(
       <VeilederInputRequestError personError={undefined} />
     )
     expect(container).toBeEmptyDOMElement()

--- a/src/router/RouteErrorBoundary/__tests__/ErrorPageUnexpected.test.tsx
+++ b/src/router/RouteErrorBoundary/__tests__/ErrorPageUnexpected.test.tsx
@@ -24,7 +24,7 @@ describe('ErrorPageUnexpected', () => {
   it('sender brukeren til landingside og tømmer storen når brukeren klikker på knappen', async () => {
     const user = userEvent.setup()
 
-    const { store } = await render(<ErrorPageUnexpected />, {
+    const { store } = render(<ErrorPageUnexpected />, {
       preloadedState: {
         userInput: {
           ...userInputInitialState,

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -73,7 +73,7 @@ function generateMockedTranslations() {
 }
 
 // Return an object with the store and all of RTL's query functions
-export async function renderWithProviders(
+export function renderWithProviders(
   ui: React.ReactElement,
   {
     preloadedState = {},
@@ -84,13 +84,17 @@ export async function renderWithProviders(
     ...renderOptions
   }: ExtendedRenderOptions = {}
 ) {
-  const promises = Object.entries(preloadedApiState).map(([key, data]) =>
+  const preloadedApiStateEntries = Object.entries(preloadedApiState)
+  if (preloadedApiStateEntries.length) {
     store.dispatch(
-      apiSlice.util.upsertQueryData(key as QueryKeys, undefined, data)
+      apiSlice.util.upsertQueryEntries(
+        preloadedApiStateEntries.map(([key, value]) => ({
+          endpointName: key as QueryKeys,
+          arg: undefined,
+          value,
+        }))
+      )
     )
-  )
-  if (promises.length) {
-    await Promise.all(promises)
   }
 
   function Wrapper({


### PR DESCRIPTION
Sorry, hadde egentlig ikke tenkt å lage flere PR-er nå, men fant en bug under jobbing med typed linting. Det viser seg at `upsertQueryData()` har en feil som gjør at man får typefeil når man prøver å mocke et api-kall der `transformResponse` er brukt til å manipulere responsen (som feks. i `getGrunnbelop`). Fant ut at det finnes en annen funksjon som er bedre egnet, nemlig [upsertQueryEntries](https://redux-toolkit.js.org/rtk-query/api/created-api/api-slice-utils#upsertqueryentries). Den kan dessuten brukes uten await.

De relevante endringene er i [test-utils.tsx](https://github.com/navikt/pensjonskalkulator-frontend/pull/2102/files#diff-eed8903eee19f840cf0180f40130fe79e0d26e1a7113173c6872461e659c3626), resten er bare fjerning av await rundtomkring.