### PR TITLE
PEK-1262: Endret tp-nummer fra 4080 til 4082

### DIFF
--- a/cypress/e2e/pensjon/kalkulator/med-samtykke-offentlig-tjenestepensjon.cy.ts
+++ b/cypress/e2e/pensjon/kalkulator/med-samtykke-offentlig-tjenestepensjon.cy.ts
@@ -381,7 +381,7 @@ describe('Med samtykke - Offentlig tjenestepensjon', () => {
             simuleringsresultatStatus: 'OK',
             muligeTpLeverandoerListe: ['Kommunal Landspensjonskasse'],
             simulertTjenestepensjon: {
-              tpNummer: '4080',
+              tpNummer: '4082',
               tpLeverandoer: 'Kommunal Landspensjonskasse',
               simuleringsresultat: {
                 utbetalingsperioder: [

--- a/src/components/Pensjonsavtaler/OffentligTjenestePensjon/__tests__/OffentligTjenestepensjon.test.tsx
+++ b/src/components/Pensjonsavtaler/OffentligTjenestePensjon/__tests__/OffentligTjenestepensjon.test.tsx
@@ -495,7 +495,7 @@ describe('OffentligTjenestepensjon', () => {
             simulertTjenestepensjon: {
               ...offentligTpData.simulertTjenestepensjon,
               tpLeverandoer: 'Kommunal Landspensjonskasse',
-              tpNummer: '4080',
+              tpNummer: '4082',
             },
           }}
           headingLevel="3"
@@ -524,7 +524,7 @@ describe('OffentligTjenestepensjon', () => {
             simulertTjenestepensjon: {
               ...offentligTpData.simulertTjenestepensjon,
               tpLeverandoer: 'Kommunal Landspensjonskasse',
-              tpNummer: '4080',
+              tpNummer: '4082',
             },
           }}
           headingLevel="3"
@@ -551,7 +551,7 @@ describe('OffentligTjenestepensjon', () => {
               simulertTjenestepensjon: {
                 ...offentligTpData.simulertTjenestepensjon,
                 tpLeverandoer: 'Kommunal Landspensjonskasse',
-                tpNummer: '4080',
+                tpNummer: '4082',
               },
             }}
             headingLevel="3"
@@ -591,7 +591,7 @@ describe('OffentligTjenestepensjon', () => {
               simulertTjenestepensjon: {
                 ...offentligTpData.simulertTjenestepensjon,
                 tpLeverandoer: 'Kommunal Landspensjonskasse',
-                tpNummer: '4080',
+                tpNummer: '4082',
               },
             }}
             headingLevel="3"
@@ -631,7 +631,7 @@ describe('OffentligTjenestepensjon', () => {
               simulertTjenestepensjon: {
                 ...offentligTpData.simulertTjenestepensjon,
                 tpLeverandoer: 'Kommunal Landspensjonskasse',
-                tpNummer: '4080',
+                tpNummer: '4082',
               },
             }}
             headingLevel="3"
@@ -671,7 +671,7 @@ describe('OffentligTjenestepensjon', () => {
               simulertTjenestepensjon: {
                 ...offentligTpData.simulertTjenestepensjon,
                 tpLeverandoer: 'Kommunal Landspensjonskasse',
-                tpNummer: '4080',
+                tpNummer: '4082',
               },
             }}
             headingLevel="3"

--- a/src/components/Pensjonsavtaler/OffentligTjenestePensjon/__tests__/utils.test.tsx
+++ b/src/components/Pensjonsavtaler/OffentligTjenestePensjon/__tests__/utils.test.tsx
@@ -34,7 +34,7 @@ describe('getLeverandoerHeading', () => {
   })
 
   it('Returnerer riktig overskrift for KLP.', () => {
-    const heading = wrappedGetLeverandoerHeading('4080', 'Fallback')
+    const heading = wrappedGetLeverandoerHeading('4082', 'Fallback')
     expect(heading).toBe('Alderspensjon fra Kommunal Landspensjonskasse (KLP)')
   })
 
@@ -48,7 +48,7 @@ describe('getInfoOmAfpOgBetingetTjenestepensjon', () => {
   describe('Gitt at leverandør er KLP,', () => {
     it('returnerer riktig infotekst når AFP==ja_offentlig.', () => {
       const heading = getInfoOmAfpOgBetingetTjenestepensjon(
-        '4080',
+        '4082',
         'ja_offentlig',
         false
       )
@@ -56,7 +56,7 @@ describe('getInfoOmAfpOgBetingetTjenestepensjon', () => {
     })
     it('returnerer riktig infotekst når AFP==ja_privat.', () => {
       const heading = getInfoOmAfpOgBetingetTjenestepensjon(
-        '4080',
+        '4082',
         'ja_privat',
         false
       )

--- a/src/components/Pensjonsavtaler/OffentligTjenestePensjon/utils.ts
+++ b/src/components/Pensjonsavtaler/OffentligTjenestePensjon/utils.ts
@@ -5,7 +5,7 @@ import type { Translations } from '@/translations/nb'
 const tpNummerTilNavn: Record<string, 'spk' | 'klp'> = {
   '3010': 'spk',
   '3060': 'spk',
-  '4080': 'klp',
+  '4082': 'klp',
   '3200': 'klp',
 }
 


### PR DESCRIPTION
Grunnet feil TP-nummer for klp, må alle 4080 nummere endres til 4082