### PR TITLE
PEK-1084: Refaktorer navigering i stegvisning

### DIFF
--- a/src/components/AvansertSkjema/AvansertSkjemaForAndreBrukere/__tests__/AvansertSkjemaForAndreBrukere.test.tsx
+++ b/src/components/AvansertSkjema/AvansertSkjemaForAndreBrukere/__tests__/AvansertSkjemaForAndreBrukere.test.tsx
@@ -1925,13 +1925,13 @@ describe('AvansertSkjemaForAndreBrukere', () => {
                   requestId: 'xTaE6mOydr5ZI75UXq4Wi',
                   startedTimeStamp: 1688046411971,
                   data: {
+                    harLoependeVedtak: true,
                     alderspensjon: {
                       grad: 100,
                       fom: new Date().toLocaleDateString('en-CA'), // dette gir dato i format yyyy-mm-dd
                       sivilstand: 'UGIFT',
                     },
                     ufoeretrygd: { grad: 0 },
-                    harLoependeVedtak: true,
                   } satisfies LoependeVedtak,
                   fulfilledTimeStamp: 1688046412103,
                 },

--- a/src/components/stegvisning/__tests__/stegvisning-hooks.test.tsx
+++ b/src/components/stegvisning/__tests__/stegvisning-hooks.test.tsx
@@ -20,11 +20,14 @@ import { RootState, setupStore } from '../../../state/store'
 import { useStegvisningNavigation } from '../stegvisning-hooks'
 
 const navigateMock = vi.fn()
-vi.mock(import('react-router'), async (importOriginal) => {
-  const actual = await importOriginal()
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router')
   return {
     ...actual,
     useNavigate: () => navigateMock,
+    createSearchParams: () => ({
+      toString: () => 'back=true',
+    }),
   }
 })
 
@@ -69,7 +72,10 @@ describe('stegvisning - hooks', () => {
 
         // onStegvisningPrevious
         result.current[0].onStegvisningPrevious()
-        expect(navigateMock).toHaveBeenCalledWith(paths.login)
+        expect(navigateMock).toHaveBeenCalledWith({
+          pathname: paths.login,
+          search: 'back=true',
+        })
 
         // onStegvisningCancel
         result.current[0].onStegvisningCancel()
@@ -86,7 +92,7 @@ describe('stegvisning - hooks', () => {
           },
         }
 
-        it('Når brukeren navigerer tilbake fra samtykke steget, er hen sendt tilbake til utenlandsopphold steget.', () => {
+        it('Når brukeren navigerer tilbake fra samtykke steget, kalles navigasjonsfunksjonen med riktig format', () => {
           const wrapper = ({ children }: { children: React.ReactNode }) => {
             const storeRef = setupStore(
               {
@@ -107,7 +113,11 @@ describe('stegvisning - hooks', () => {
           })
 
           result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.utenlandsopphold)
+          expect(navigateMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+              search: 'back=true',
+            })
+          )
         })
       })
 
@@ -120,7 +130,7 @@ describe('stegvisning - hooks', () => {
           },
         }
 
-        it('Når brukeren navigerer tilbake fra samtykke steget, er hen sendt tilbake til utenlandsopphold steget.', () => {
+        it('Når brukeren navigerer tilbake fra samtykke steget, kalles navigasjonsfunksjonen med riktig format', () => {
           const wrapper = ({ children }: { children: React.ReactNode }) => {
             const storeRef = setupStore(
               {
@@ -142,7 +152,11 @@ describe('stegvisning - hooks', () => {
 
           // onStegvisningPrevious
           result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.utenlandsopphold)
+          expect(navigateMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+              search: 'back=true',
+            })
+          )
         })
       })
 
@@ -155,7 +169,7 @@ describe('stegvisning - hooks', () => {
           },
         }
 
-        it('Når brukeren har svart "nei" på AFP steget og navigerer tilbake fra samtykke steget, er hen sendt tilbake til afp steget.', () => {
+        it('Når brukeren har svart "nei" på AFP steget og navigerer tilbake fra samtykke steget, kalles navigasjonsfunksjonen med riktig format', () => {
           const wrapper = ({ children }: { children: React.ReactNode }) => {
             const storeRef = setupStore(
               {
@@ -177,10 +191,14 @@ describe('stegvisning - hooks', () => {
 
           // onStegvisningPrevious
           result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+          expect(navigateMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+              search: 'back=true',
+            })
+          )
         })
 
-        it('Når brukeren har svart ja på AFP-steget og navigerer tilbake fra samtykke steget, er hen sendt tilbake til ufoeretrygdAFP steget.', () => {
+        it('Når brukeren har svart ja på AFP-steget og navigerer tilbake fra samtykke steget, kalles navigasjonsfunksjonen med riktig format', () => {
           const wrapper = ({ children }: { children: React.ReactNode }) => {
             const storeRef = setupStore(
               {
@@ -202,7 +220,11 @@ describe('stegvisning - hooks', () => {
 
           // onStegvisningPrevious
           result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.ufoeretrygdAFP)
+          expect(navigateMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+              search: 'back=true',
+            })
+          )
         })
 
         it('Når brukeren navigerer tilbake fra ufoeretrygdAFP steget, er hen sendt tilbake til afp steget.', () => {
@@ -227,7 +249,10 @@ describe('stegvisning - hooks', () => {
 
           // onStegvisningPrevious
           result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+          expect(navigateMock).toHaveBeenCalledWith({
+            pathname: paths.afp,
+            search: 'back=true',
+          })
         })
       })
 
@@ -240,7 +265,7 @@ describe('stegvisning - hooks', () => {
           },
         }
 
-        it('Når brukeren navigerer tilbake fra samtykke steget, er hen sendt tilbake til afp steget.', () => {
+        it('Når brukeren navigerer tilbake fra samtykke steget, kalles navigasjonsfunksjonen med riktig format', () => {
           const wrapper = ({ children }: { children: React.ReactNode }) => {
             const storeRef = setupStore(
               {
@@ -262,7 +287,11 @@ describe('stegvisning - hooks', () => {
 
           // onStegvisningPrevious
           result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+          expect(navigateMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+              search: 'back=true',
+            })
+          )
         })
       })
     })
@@ -310,7 +339,10 @@ describe('stegvisning - hooks', () => {
 
         // onStegvisningPrevious
         result.current[0].onStegvisningPrevious()
-        expect(navigateMock).toHaveBeenCalledWith(paths.login)
+        expect(navigateMock).toHaveBeenCalledWith({
+          pathname: paths.login,
+          search: 'back=true',
+        })
 
         // onStegvisningCancel
         result.current[0].onStegvisningCancel()
@@ -349,7 +381,10 @@ describe('stegvisning - hooks', () => {
 
           // onStegvisningPrevious
           result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+          expect(navigateMock).toHaveBeenCalledWith({
+            pathname: paths.afp,
+            search: 'back=true',
+          })
         })
       })
 
@@ -362,7 +397,7 @@ describe('stegvisning - hooks', () => {
           },
         }
 
-        it('Når brukeren har svart "ja_offentlig" og navigerer tilbake fra samtykkeOffentligAFP, er hen sendt tilbake til afp steget.', () => {
+        it('Når brukeren har svart "ja_offentlig" og navigerer tilbake fra samtykkeOffentligAFP, kalles navigasjonsfunksjonen med riktig format', () => {
           const wrapper = ({ children }: { children: React.ReactNode }) => {
             const storeRef = setupStore(
               {
@@ -384,7 +419,11 @@ describe('stegvisning - hooks', () => {
 
           // onStegvisningPrevious
           result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+          expect(navigateMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+              search: 'back=true',
+            })
+          )
         })
       })
     })

--- a/src/components/stegvisning/__tests__/stegvisning-hooks.test.tsx
+++ b/src/components/stegvisning/__tests__/stegvisning-hooks.test.tsx
@@ -2,14 +2,7 @@ import { Provider } from 'react-redux'
 
 import {
   fulfilledGetLoependeVedtak0Ufoeregrad,
-  fulfilledGetLoependeVedtak75Ufoeregrad,
-  fulfilledGetLoependeVedtak100Ufoeregrad,
   fulfilledGetLoependeVedtakLoepende50Alderspensjon,
-  fulfilledGetLoependeVedtakLoependeAlderspensjon,
-  fulfilledGetLoependeVedtakLoependeAlderspensjonOg40Ufoeretrygd,
-  fulfilledGetPerson,
-  fulfilledGetPersonEldreEnnAfpUfoereOppsigelsesalder,
-  fulfilledGetPersonYngreEnnAfpUfoereOppsigelsesalder,
 } from '@/mocks/mockedRTKQueryApiCalls'
 import { paths } from '@/router/constants'
 import { userInputInitialState } from '@/state/userInput/userInputSlice'
@@ -25,6 +18,9 @@ vi.mock(import('react-router'), async (importOriginal) => {
   return {
     ...actual,
     useNavigate: () => navigateMock,
+    createSearchParams: () => ({
+      toString: () => 'back=true',
+    }),
   }
 })
 
@@ -35,7 +31,62 @@ describe('stegvisning - hooks', () => {
         vi.resetAllMocks()
       })
 
-      it('navigerer riktig fremover, bakover og ved kansellering.', () => {
+      it('navigerer riktig fremover', () => {
+        const mockedState = {
+          api: {
+            // @ts-ignore
+            queries: {
+              ...fulfilledGetLoependeVedtak0Ufoeregrad,
+            },
+          },
+          userInput: { ...userInputInitialState },
+        }
+
+        const wrapper = ({ children }: { children: React.ReactNode }) => {
+          const storeRef = setupStore(mockedState as unknown as RootState, true)
+          return <Provider store={storeRef}>{children}</Provider>
+        }
+
+        const { result } = renderHook(useStegvisningNavigation, {
+          wrapper,
+          initialProps: paths.start,
+        })
+
+        if (result.current[0].onStegvisningNext) {
+          result.current[0].onStegvisningNext()
+        }
+        expect(navigateMock).toHaveBeenCalledWith(paths.sivilstand)
+      })
+
+      it('navigerer riktig bakover', () => {
+        const mockedState = {
+          api: {
+            // @ts-ignore
+            queries: {
+              ...fulfilledGetLoependeVedtak0Ufoeregrad,
+            },
+          },
+          userInput: { ...userInputInitialState },
+        }
+
+        const wrapper = ({ children }: { children: React.ReactNode }) => {
+          const storeRef = setupStore(mockedState as unknown as RootState, true)
+          return <Provider store={storeRef}>{children}</Provider>
+        }
+
+        const { result } = renderHook(useStegvisningNavigation, {
+          wrapper,
+          initialProps: paths.start,
+        })
+
+        result.current[0].onStegvisningPrevious()
+        expect(navigateMock).toHaveBeenCalledWith({
+          pathname: paths.login,
+          search: 'back=true',
+        })
+      })
+
+      it('kansellerer riktig', () => {
         const flushMock = vi.spyOn(
           userInputReducerUtils.userInputActions,
           'flush'
@@ -61,222 +112,73 @@ describe('stegvisning - hooks', () => {
           initialProps: paths.start,
         })
 
-        // onStegvisningNext
-        if (result.current[0].onStegvisningNext) {
-          result.current[0].onStegvisningNext()
-        }
-        expect(navigateMock).toHaveBeenCalledWith(paths.sivilstand)
-
-        // onStegvisningPrevious
-        result.current[0].onStegvisningPrevious()
-        expect(navigateMock).toHaveBeenCalledWith(paths.login)
-
-        // onStegvisningCancel
         result.current[0].onStegvisningCancel()
         expect(navigateMock).toHaveBeenCalledWith(paths.login)
         expect(flushMock).toHaveBeenCalled()
       })
-
-      describe('Gitt at brukeren har 100 % uføretrygd', () => {
-        const apiMock = {
-          // @ts-ignore
-          queries: {
-            ...fulfilledGetLoependeVedtak100Ufoeregrad,
-            ...fulfilledGetPerson,
-          },
-        }
-
-        it('Når brukeren navigerer tilbake fra samtykke steget, er hen sendt tilbake til utenlandsopphold steget.', () => {
-          const wrapper = ({ children }: { children: React.ReactNode }) => {
-            const storeRef = setupStore(
-              {
-                // @ts-ignore
-                api: {
-                  ...apiMock,
-                },
-                userInput: { ...userInputInitialState },
-              },
-              true
-            )
-            return <Provider store={storeRef}>{children}</Provider>
-          }
-
-          const { result } = renderHook(useStegvisningNavigation, {
-            wrapper,
-            initialProps: paths.samtykke,
-          })
-
-          result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.utenlandsopphold)
-        })
-      })
-
-      describe('Gitt at brukeren har gradert uføretrygd og er eldre enn AFP-Uføre oppsigelsesalder,', () => {
-        const apiMock = {
-          // @ts-ignore
-          queries: {
-            ...fulfilledGetLoependeVedtak75Ufoeregrad,
-            ...fulfilledGetPersonEldreEnnAfpUfoereOppsigelsesalder,
-          },
-        }
-
-        it('Når brukeren navigerer tilbake fra samtykke steget, er hen sendt tilbake til utenlandsopphold steget.', () => {
-          const wrapper = ({ children }: { children: React.ReactNode }) => {
-            const storeRef = setupStore(
-              {
-                // @ts-ignore
-                api: {
-                  ...apiMock,
-                },
-                userInput: { ...userInputInitialState },
-              },
-              true
-            )
-            return <Provider store={storeRef}>{children}</Provider>
-          }
-
-          const { result } = renderHook(useStegvisningNavigation, {
-            wrapper,
-            initialProps: paths.samtykke,
-          })
-
-          // onStegvisningPrevious
-          result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.utenlandsopphold)
-        })
-      })
-
-      describe('Gitt at brukeren har gradert uføretrygd og er yngre enn AFP-Uføre oppsigelsesalder,', () => {
-        const apiMock = {
-          // @ts-ignore
-          queries: {
-            ...fulfilledGetLoependeVedtak75Ufoeregrad,
-            ...fulfilledGetPersonYngreEnnAfpUfoereOppsigelsesalder,
-          },
-        }
-
-        it('Når brukeren har svart "nei" på AFP steget og navigerer tilbake fra samtykke steget, er hen sendt tilbake til afp steget.', () => {
-          const wrapper = ({ children }: { children: React.ReactNode }) => {
-            const storeRef = setupStore(
-              {
-                // @ts-ignore
-                api: {
-                  ...apiMock,
-                },
-                userInput: { ...userInputInitialState, afp: 'nei' },
-              },
-              true
-            )
-            return <Provider store={storeRef}>{children}</Provider>
-          }
-
-          const { result } = renderHook(useStegvisningNavigation, {
-            wrapper,
-            initialProps: paths.samtykke,
-          })
-
-          // onStegvisningPrevious
-          result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
-        })
-
-        it('Når brukeren har svart ja på AFP-steget og navigerer tilbake fra samtykke steget, er hen sendt tilbake til ufoeretrygdAFP steget.', () => {
-          const wrapper = ({ children }: { children: React.ReactNode }) => {
-            const storeRef = setupStore(
-              {
-                // @ts-ignore
-                api: {
-                  ...apiMock,
-                },
-                userInput: { ...userInputInitialState, afp: 'ja_offentlig' },
-              },
-              true
-            )
-            return <Provider store={storeRef}>{children}</Provider>
-          }
-
-          const { result } = renderHook(useStegvisningNavigation, {
-            wrapper,
-            initialProps: paths.samtykke,
-          })
-
-          // onStegvisningPrevious
-          result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.ufoeretrygdAFP)
-        })
-
-        it('Når brukeren navigerer tilbake fra ufoeretrygdAFP steget, er hen sendt tilbake til afp steget.', () => {
-          const wrapper = ({ children }: { children: React.ReactNode }) => {
-            const storeRef = setupStore(
-              {
-                // @ts-ignore
-                api: {
-                  ...apiMock,
-                },
-                userInput: { ...userInputInitialState, afp: 'ja_offentlig' },
-              },
-              true
-            )
-            return <Provider store={storeRef}>{children}</Provider>
-          }
-
-          const { result } = renderHook(useStegvisningNavigation, {
-            wrapper,
-            initialProps: paths.ufoeretrygdAFP,
-          })
-
-          // onStegvisningPrevious
-          result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
-        })
-      })
-
-      describe('Gitt at brukeren ikke har uføretrygd og har svart noe annet enn "ja_offentlig" på AFP steget,', () => {
-        const apiMock = {
-          // @ts-ignore
-          queries: {
-            ...fulfilledGetLoependeVedtak0Ufoeregrad,
-            ...fulfilledGetPerson,
-          },
-        }
-
-        it('Når brukeren navigerer tilbake fra samtykke steget, er hen sendt tilbake til afp steget.', () => {
-          const wrapper = ({ children }: { children: React.ReactNode }) => {
-            const storeRef = setupStore(
-              {
-                // @ts-ignore
-                api: {
-                  ...apiMock,
-                },
-                userInput: { ...userInputInitialState, afp: 'ja_privat' },
-              },
-              true
-            )
-            return <Provider store={storeRef}>{children}</Provider>
-          }
-
-          const { result } = renderHook(useStegvisningNavigation, {
-            wrapper,
-            initialProps: paths.samtykke,
-          })
-
-          // onStegvisningPrevious
-          result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
-        })
-      })
     })
 
-    describe('Gitt at brukeren har et vedtak om alderspensjon eller AFP', () => {
+    describe('Gitt at brukeren har et vedtak om alderspensjon eller AFP (endringsløp)', () => {
       afterEach(() => {
         vi.resetAllMocks()
       })
 
-      // Andre case oppstår:
-      // brukere med uføretrygd eldre enn AFP-Uføre oppsigelsesalder får ikke AFP steg og går da direkte til beregning (ingen tilbakeknapp der)
-      // brukere med AFP vedtak får ikke AFP steg og går da direkte til beregning (ingen tilbakeknapp der)
+      it('navigerer riktig fremover', () => {
+        const mockedState = {
+          api: {
+            // @ts-ignore
+            queries: {
+              ...fulfilledGetLoependeVedtakLoepende50Alderspensjon,
+            },
+          },
+          userInput: { ...userInputInitialState },
+        }
 
-      it('navigerer riktig fremover, bakover og ved kansellering.', () => {
+        const wrapper = ({ children }: { children: React.ReactNode }) => {
+          const storeRef = setupStore(mockedState as unknown as RootState, true)
+          return <Provider store={storeRef}>{children}</Provider>
+        }
+
+        const { result } = renderHook(useStegvisningNavigation, {
+          wrapper,
+          initialProps: paths.start,
+        })
+
+        if (result.current[0].onStegvisningNext) {
+          result.current[0].onStegvisningNext()
+        }
+        expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+      })
+
+      it('navigerer riktig bakover', () => {
+        const mockedState = {
+          api: {
+            // @ts-ignore
+            queries: {
+              ...fulfilledGetLoependeVedtakLoepende50Alderspensjon,
+            },
+          },
+          userInput: { ...userInputInitialState },
+        }
+
+        const wrapper = ({ children }: { children: React.ReactNode }) => {
+          const storeRef = setupStore(mockedState as unknown as RootState, true)
+          return <Provider store={storeRef}>{children}</Provider>
+        }
+
+        const { result } = renderHook(useStegvisningNavigation, {
+          wrapper,
+          initialProps: paths.start,
+        })
+
+        result.current[0].onStegvisningPrevious()
+        expect(navigateMock).toHaveBeenCalledWith({
+          pathname: paths.login,
+          search: 'back=true',
+        })
+      })
+
+      it('kansellerer riktig', () => {
         const flushMock = vi.spyOn(
           userInputReducerUtils.userInputActions,
           'flush'
@@ -302,90 +204,9 @@ describe('stegvisning - hooks', () => {
           initialProps: paths.start,
         })
 
-        // onStegvisningNext
-        if (result.current[0].onStegvisningNext) {
-          result.current[0].onStegvisningNext()
-        }
-        expect(navigateMock).toHaveBeenCalledWith(paths.afp)
-
-        // onStegvisningPrevious
-        result.current[0].onStegvisningPrevious()
-        expect(navigateMock).toHaveBeenCalledWith(paths.login)
-
-        // onStegvisningCancel
         result.current[0].onStegvisningCancel()
         expect(navigateMock).toHaveBeenCalledWith(paths.login)
         expect(flushMock).toHaveBeenCalled()
-      })
-
-      describe('Gitt at brukeren har uføretrygd og er yngre enn AFP-Uføre oppsigelsesalder,', () => {
-        const apiMock = {
-          // @ts-ignore
-          queries: {
-            ...fulfilledGetLoependeVedtakLoependeAlderspensjonOg40Ufoeretrygd,
-            ...fulfilledGetPersonYngreEnnAfpUfoereOppsigelsesalder,
-          },
-        }
-
-        it('Når brukeren navigerer tilbake fra ufoeretrygdAFP steget, er hen sendt tilbake til afp steget.', () => {
-          const wrapper = ({ children }: { children: React.ReactNode }) => {
-            const storeRef = setupStore(
-              {
-                // @ts-ignore
-                api: {
-                  ...apiMock,
-                },
-                userInput: { ...userInputInitialState, afp: 'ja_offentlig' },
-              },
-              true
-            )
-            return <Provider store={storeRef}>{children}</Provider>
-          }
-
-          const { result } = renderHook(useStegvisningNavigation, {
-            wrapper,
-            initialProps: paths.ufoeretrygdAFP,
-          })
-
-          // onStegvisningPrevious
-          result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
-        })
-      })
-
-      describe('Gitt at brukeren ikke har uføretrygd,', () => {
-        const apiMock = {
-          // @ts-ignore
-          queries: {
-            ...fulfilledGetLoependeVedtakLoependeAlderspensjon,
-            ...fulfilledGetPerson,
-          },
-        }
-
-        it('Når brukeren har svart "ja_offentlig" og navigerer tilbake fra samtykkeOffentligAFP, er hen sendt tilbake til afp steget.', () => {
-          const wrapper = ({ children }: { children: React.ReactNode }) => {
-            const storeRef = setupStore(
-              {
-                // @ts-ignore
-                api: {
-                  ...apiMock,
-                },
-                userInput: { ...userInputInitialState, afp: 'ja_offentlig' },
-              },
-              true
-            )
-            return <Provider store={storeRef}>{children}</Provider>
-          }
-
-          const { result } = renderHook(useStegvisningNavigation, {
-            wrapper,
-            initialProps: paths.samtykkeOffentligAFP,
-          })
-
-          // onStegvisningPrevious
-          result.current[0].onStegvisningPrevious()
-          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
-        })
       })
     })
   })

--- a/src/components/stegvisning/__tests__/stegvisning-hooks.test.tsx
+++ b/src/components/stegvisning/__tests__/stegvisning-hooks.test.tsx
@@ -2,7 +2,14 @@ import { Provider } from 'react-redux'
 
 import {
   fulfilledGetLoependeVedtak0Ufoeregrad,
+  fulfilledGetLoependeVedtak75Ufoeregrad,
+  fulfilledGetLoependeVedtak100Ufoeregrad,
   fulfilledGetLoependeVedtakLoepende50Alderspensjon,
+  fulfilledGetLoependeVedtakLoependeAlderspensjon,
+  fulfilledGetLoependeVedtakLoependeAlderspensjonOg40Ufoeretrygd,
+  fulfilledGetPerson,
+  fulfilledGetPersonEldreEnnAfpUfoereOppsigelsesalder,
+  fulfilledGetPersonYngreEnnAfpUfoereOppsigelsesalder,
 } from '@/mocks/mockedRTKQueryApiCalls'
 import { paths } from '@/router/constants'
 import { userInputInitialState } from '@/state/userInput/userInputSlice'
@@ -18,9 +25,6 @@ vi.mock(import('react-router'), async (importOriginal) => {
   return {
     ...actual,
     useNavigate: () => navigateMock,
-    createSearchParams: () => ({
-      toString: () => 'back=true',
-    }),
   }
 })
 
@@ -31,7 +35,12 @@ describe('stegvisning - hooks', () => {
         vi.resetAllMocks()
       })
 
-      it('navigerer riktig fremover', () => {
+      it('navigerer riktig fremover, bakover og ved kansellering.', () => {
+        const flushMock = vi.spyOn(
+          userInputReducerUtils.userInputActions,
+          'flush'
+        )
+
         const mockedState = {
           api: {
             // @ts-ignore
@@ -52,133 +61,222 @@ describe('stegvisning - hooks', () => {
           initialProps: paths.start,
         })
 
+        // onStegvisningNext
         if (result.current[0].onStegvisningNext) {
           result.current[0].onStegvisningNext()
         }
         expect(navigateMock).toHaveBeenCalledWith(paths.sivilstand)
-      })
 
-      it('navigerer riktig bakover', () => {
-        const mockedState = {
-          api: {
-            // @ts-ignore
-            queries: {
-              ...fulfilledGetLoependeVedtak0Ufoeregrad,
-            },
-          },
-          userInput: { ...userInputInitialState },
-        }
-
-        const wrapper = ({ children }: { children: React.ReactNode }) => {
-          const storeRef = setupStore(mockedState as unknown as RootState, true)
-          return <Provider store={storeRef}>{children}</Provider>
-        }
-
-        const { result } = renderHook(useStegvisningNavigation, {
-          wrapper,
-          initialProps: paths.start,
-        })
-
+        // onStegvisningPrevious
         result.current[0].onStegvisningPrevious()
-        expect(navigateMock).toHaveBeenCalledWith({
-          pathname: paths.login,
-          search: 'back=true',
-        })
-      })
+        expect(navigateMock).toHaveBeenCalledWith(paths.login)
 
-      it('kansellerer riktig', () => {
-        const flushMock = vi.spyOn(
-          userInputReducerUtils.userInputActions,
-          'flush'
-        )
-
-        const mockedState = {
-          api: {
-            // @ts-ignore
-            queries: {
-              ...fulfilledGetLoependeVedtak0Ufoeregrad,
-            },
-          },
-          userInput: { ...userInputInitialState },
-        }
-
-        const wrapper = ({ children }: { children: React.ReactNode }) => {
-          const storeRef = setupStore(mockedState as unknown as RootState, true)
-          return <Provider store={storeRef}>{children}</Provider>
-        }
-
-        const { result } = renderHook(useStegvisningNavigation, {
-          wrapper,
-          initialProps: paths.start,
-        })
-
+        // onStegvisningCancel
         result.current[0].onStegvisningCancel()
         expect(navigateMock).toHaveBeenCalledWith(paths.login)
         expect(flushMock).toHaveBeenCalled()
       })
+
+      describe('Gitt at brukeren har 100 % uføretrygd', () => {
+        const apiMock = {
+          // @ts-ignore
+          queries: {
+            ...fulfilledGetLoependeVedtak100Ufoeregrad,
+            ...fulfilledGetPerson,
+          },
+        }
+
+        it('Når brukeren navigerer tilbake fra samtykke steget, er hen sendt tilbake til utenlandsopphold steget.', () => {
+          const wrapper = ({ children }: { children: React.ReactNode }) => {
+            const storeRef = setupStore(
+              {
+                // @ts-ignore
+                api: {
+                  ...apiMock,
+                },
+                userInput: { ...userInputInitialState },
+              },
+              true
+            )
+            return <Provider store={storeRef}>{children}</Provider>
+          }
+
+          const { result } = renderHook(useStegvisningNavigation, {
+            wrapper,
+            initialProps: paths.samtykke,
+          })
+
+          result.current[0].onStegvisningPrevious()
+          expect(navigateMock).toHaveBeenCalledWith(paths.utenlandsopphold)
+        })
+      })
+
+      describe('Gitt at brukeren har gradert uføretrygd og er eldre enn AFP-Uføre oppsigelsesalder,', () => {
+        const apiMock = {
+          // @ts-ignore
+          queries: {
+            ...fulfilledGetLoependeVedtak75Ufoeregrad,
+            ...fulfilledGetPersonEldreEnnAfpUfoereOppsigelsesalder,
+          },
+        }
+
+        it('Når brukeren navigerer tilbake fra samtykke steget, er hen sendt tilbake til utenlandsopphold steget.', () => {
+          const wrapper = ({ children }: { children: React.ReactNode }) => {
+            const storeRef = setupStore(
+              {
+                // @ts-ignore
+                api: {
+                  ...apiMock,
+                },
+                userInput: { ...userInputInitialState },
+              },
+              true
+            )
+            return <Provider store={storeRef}>{children}</Provider>
+          }
+
+          const { result } = renderHook(useStegvisningNavigation, {
+            wrapper,
+            initialProps: paths.samtykke,
+          })
+
+          // onStegvisningPrevious
+          result.current[0].onStegvisningPrevious()
+          expect(navigateMock).toHaveBeenCalledWith(paths.utenlandsopphold)
+        })
+      })
+
+      describe('Gitt at brukeren har gradert uføretrygd og er yngre enn AFP-Uføre oppsigelsesalder,', () => {
+        const apiMock = {
+          // @ts-ignore
+          queries: {
+            ...fulfilledGetLoependeVedtak75Ufoeregrad,
+            ...fulfilledGetPersonYngreEnnAfpUfoereOppsigelsesalder,
+          },
+        }
+
+        it('Når brukeren har svart "nei" på AFP steget og navigerer tilbake fra samtykke steget, er hen sendt tilbake til afp steget.', () => {
+          const wrapper = ({ children }: { children: React.ReactNode }) => {
+            const storeRef = setupStore(
+              {
+                // @ts-ignore
+                api: {
+                  ...apiMock,
+                },
+                userInput: { ...userInputInitialState, afp: 'nei' },
+              },
+              true
+            )
+            return <Provider store={storeRef}>{children}</Provider>
+          }
+
+          const { result } = renderHook(useStegvisningNavigation, {
+            wrapper,
+            initialProps: paths.samtykke,
+          })
+
+          // onStegvisningPrevious
+          result.current[0].onStegvisningPrevious()
+          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+        })
+
+        it('Når brukeren har svart ja på AFP-steget og navigerer tilbake fra samtykke steget, er hen sendt tilbake til ufoeretrygdAFP steget.', () => {
+          const wrapper = ({ children }: { children: React.ReactNode }) => {
+            const storeRef = setupStore(
+              {
+                // @ts-ignore
+                api: {
+                  ...apiMock,
+                },
+                userInput: { ...userInputInitialState, afp: 'ja_offentlig' },
+              },
+              true
+            )
+            return <Provider store={storeRef}>{children}</Provider>
+          }
+
+          const { result } = renderHook(useStegvisningNavigation, {
+            wrapper,
+            initialProps: paths.samtykke,
+          })
+
+          // onStegvisningPrevious
+          result.current[0].onStegvisningPrevious()
+          expect(navigateMock).toHaveBeenCalledWith(paths.ufoeretrygdAFP)
+        })
+
+        it('Når brukeren navigerer tilbake fra ufoeretrygdAFP steget, er hen sendt tilbake til afp steget.', () => {
+          const wrapper = ({ children }: { children: React.ReactNode }) => {
+            const storeRef = setupStore(
+              {
+                // @ts-ignore
+                api: {
+                  ...apiMock,
+                },
+                userInput: { ...userInputInitialState, afp: 'ja_offentlig' },
+              },
+              true
+            )
+            return <Provider store={storeRef}>{children}</Provider>
+          }
+
+          const { result } = renderHook(useStegvisningNavigation, {
+            wrapper,
+            initialProps: paths.ufoeretrygdAFP,
+          })
+
+          // onStegvisningPrevious
+          result.current[0].onStegvisningPrevious()
+          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+        })
+      })
+
+      describe('Gitt at brukeren ikke har uføretrygd og har svart noe annet enn "ja_offentlig" på AFP steget,', () => {
+        const apiMock = {
+          // @ts-ignore
+          queries: {
+            ...fulfilledGetLoependeVedtak0Ufoeregrad,
+            ...fulfilledGetPerson,
+          },
+        }
+
+        it('Når brukeren navigerer tilbake fra samtykke steget, er hen sendt tilbake til afp steget.', () => {
+          const wrapper = ({ children }: { children: React.ReactNode }) => {
+            const storeRef = setupStore(
+              {
+                // @ts-ignore
+                api: {
+                  ...apiMock,
+                },
+                userInput: { ...userInputInitialState, afp: 'ja_privat' },
+              },
+              true
+            )
+            return <Provider store={storeRef}>{children}</Provider>
+          }
+
+          const { result } = renderHook(useStegvisningNavigation, {
+            wrapper,
+            initialProps: paths.samtykke,
+          })
+
+          // onStegvisningPrevious
+          result.current[0].onStegvisningPrevious()
+          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+        })
+      })
     })
 
-    describe('Gitt at brukeren har et vedtak om alderspensjon eller AFP (endringsløp)', () => {
+    describe('Gitt at brukeren har et vedtak om alderspensjon eller AFP', () => {
       afterEach(() => {
         vi.resetAllMocks()
       })
 
-      it('navigerer riktig fremover', () => {
-        const mockedState = {
-          api: {
-            // @ts-ignore
-            queries: {
-              ...fulfilledGetLoependeVedtakLoepende50Alderspensjon,
-            },
-          },
-          userInput: { ...userInputInitialState },
-        }
+      // Andre case oppstår:
+      // brukere med uføretrygd eldre enn AFP-Uføre oppsigelsesalder får ikke AFP steg og går da direkte til beregning (ingen tilbakeknapp der)
+      // brukere med AFP vedtak får ikke AFP steg og går da direkte til beregning (ingen tilbakeknapp der)
 
-        const wrapper = ({ children }: { children: React.ReactNode }) => {
-          const storeRef = setupStore(mockedState as unknown as RootState, true)
-          return <Provider store={storeRef}>{children}</Provider>
-        }
-
-        const { result } = renderHook(useStegvisningNavigation, {
-          wrapper,
-          initialProps: paths.start,
-        })
-
-        if (result.current[0].onStegvisningNext) {
-          result.current[0].onStegvisningNext()
-        }
-        expect(navigateMock).toHaveBeenCalledWith(paths.afp)
-      })
-
-      it('navigerer riktig bakover', () => {
-        const mockedState = {
-          api: {
-            // @ts-ignore
-            queries: {
-              ...fulfilledGetLoependeVedtakLoepende50Alderspensjon,
-            },
-          },
-          userInput: { ...userInputInitialState },
-        }
-
-        const wrapper = ({ children }: { children: React.ReactNode }) => {
-          const storeRef = setupStore(mockedState as unknown as RootState, true)
-          return <Provider store={storeRef}>{children}</Provider>
-        }
-
-        const { result } = renderHook(useStegvisningNavigation, {
-          wrapper,
-          initialProps: paths.start,
-        })
-
-        result.current[0].onStegvisningPrevious()
-        expect(navigateMock).toHaveBeenCalledWith({
-          pathname: paths.login,
-          search: 'back=true',
-        })
-      })
-
-      it('kansellerer riktig', () => {
+      it('navigerer riktig fremover, bakover og ved kansellering.', () => {
         const flushMock = vi.spyOn(
           userInputReducerUtils.userInputActions,
           'flush'
@@ -204,9 +302,90 @@ describe('stegvisning - hooks', () => {
           initialProps: paths.start,
         })
 
+        // onStegvisningNext
+        if (result.current[0].onStegvisningNext) {
+          result.current[0].onStegvisningNext()
+        }
+        expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+
+        // onStegvisningPrevious
+        result.current[0].onStegvisningPrevious()
+        expect(navigateMock).toHaveBeenCalledWith(paths.login)
+
+        // onStegvisningCancel
         result.current[0].onStegvisningCancel()
         expect(navigateMock).toHaveBeenCalledWith(paths.login)
         expect(flushMock).toHaveBeenCalled()
+      })
+
+      describe('Gitt at brukeren har uføretrygd og er yngre enn AFP-Uføre oppsigelsesalder,', () => {
+        const apiMock = {
+          // @ts-ignore
+          queries: {
+            ...fulfilledGetLoependeVedtakLoependeAlderspensjonOg40Ufoeretrygd,
+            ...fulfilledGetPersonYngreEnnAfpUfoereOppsigelsesalder,
+          },
+        }
+
+        it('Når brukeren navigerer tilbake fra ufoeretrygdAFP steget, er hen sendt tilbake til afp steget.', () => {
+          const wrapper = ({ children }: { children: React.ReactNode }) => {
+            const storeRef = setupStore(
+              {
+                // @ts-ignore
+                api: {
+                  ...apiMock,
+                },
+                userInput: { ...userInputInitialState, afp: 'ja_offentlig' },
+              },
+              true
+            )
+            return <Provider store={storeRef}>{children}</Provider>
+          }
+
+          const { result } = renderHook(useStegvisningNavigation, {
+            wrapper,
+            initialProps: paths.ufoeretrygdAFP,
+          })
+
+          // onStegvisningPrevious
+          result.current[0].onStegvisningPrevious()
+          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+        })
+      })
+
+      describe('Gitt at brukeren ikke har uføretrygd,', () => {
+        const apiMock = {
+          // @ts-ignore
+          queries: {
+            ...fulfilledGetLoependeVedtakLoependeAlderspensjon,
+            ...fulfilledGetPerson,
+          },
+        }
+
+        it('Når brukeren har svart "ja_offentlig" og navigerer tilbake fra samtykkeOffentligAFP, er hen sendt tilbake til afp steget.', () => {
+          const wrapper = ({ children }: { children: React.ReactNode }) => {
+            const storeRef = setupStore(
+              {
+                // @ts-ignore
+                api: {
+                  ...apiMock,
+                },
+                userInput: { ...userInputInitialState, afp: 'ja_offentlig' },
+              },
+              true
+            )
+            return <Provider store={storeRef}>{children}</Provider>
+          }
+
+          const { result } = renderHook(useStegvisningNavigation, {
+            wrapper,
+            initialProps: paths.samtykkeOffentligAFP,
+          })
+
+          // onStegvisningPrevious
+          result.current[0].onStegvisningPrevious()
+          expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+        })
       })
     })
   })

--- a/src/components/stegvisning/stegvisning-hooks.tsx
+++ b/src/components/stegvisning/stegvisning-hooks.tsx
@@ -1,90 +1,39 @@
 import React from 'react'
-import { useNavigate } from 'react-router'
+import { createSearchParams, useNavigate } from 'react-router'
 
-import {
-  paths,
-  stegvisningOrder,
-  stegvisningOrderEndring,
-} from '@/router/constants'
+import { paths } from '@/router/constants'
 import { useGetLoependeVedtakQuery } from '@/state/api/apiSlice'
-import { useAppDispatch, useAppSelector } from '@/state/hooks'
-import {
-  selectAfp,
-  selectFoedselsdato,
-  selectUfoeregrad,
-} from '@/state/userInput/selectors'
+import { useAppDispatch } from '@/state/hooks'
 import { userInputActions } from '@/state/userInput/userInputSlice'
-import {
-  AFP_UFOERE_OPPSIGELSESALDER,
-  isFoedselsdatoOverAlder,
-} from '@/utils/alder'
 import { isLoependeVedtakEndring } from '@/utils/loependeVedtak'
 
-export const useStegvisningNavigation = (
-  currentPath: (typeof stegvisningOrder)[number] | typeof paths.uventetFeil
-) => {
+import { getStepArrays } from './utils'
+
+type Path = (typeof paths)[keyof typeof paths]
+
+export const useStegvisningNavigation = (currentPath: Path) => {
   const navigate = useNavigate()
   const dispatch = useAppDispatch()
 
-  const foedselsdato = useAppSelector(selectFoedselsdato)
-  const ufoeregrad = useAppSelector(selectUfoeregrad)
-  const afp = useAppSelector(selectAfp)
-
   const { isFetching, data: loependeVedtak } = useGetLoependeVedtakQuery()
 
+  const isEndring = loependeVedtak && isLoependeVedtakEndring(loependeVedtak)
+
+  const stepArrays = getStepArrays(isEndring)
+
   const onStegvisningNext = () => {
-    const stepArrays: readonly string[] =
-      loependeVedtak && isLoependeVedtakEndring(loependeVedtak)
-        ? stegvisningOrderEndring
-        : stegvisningOrder
-    navigate(stepArrays[stepArrays.indexOf(currentPath) + 1])
+    const currentPathIndex = stepArrays.indexOf(currentPath)
+    navigate(stepArrays[currentPathIndex + 1])
   }
 
   const onStegvisningPrevious = () => {
-    let antallStepTilbake = 1
-    const isEndring = loependeVedtak && isLoependeVedtakEndring(loependeVedtak)
-    const stepArrays: readonly string[] = isEndring
-      ? stegvisningOrderEndring
-      : stegvisningOrder
-
     const currentPathIndex = stepArrays.indexOf(currentPath)
-
-    // Hvis brukeren er forbi afp steget (gjelder både endring og vanlig flyt)
-    if (currentPathIndex > stepArrays.indexOf(paths.afp)) {
-      // Bruker med uføretrygd som er eldre enn AFP-Uføre oppsigelsesalder har ikke fått steg om AFP og skal navigere tilbake forbi den
-      if (
-        ufoeregrad &&
-        foedselsdato &&
-        isFoedselsdatoOverAlder(foedselsdato, AFP_UFOERE_OPPSIGELSESALDER)
-      ) {
-        antallStepTilbake = antallStepTilbake + 1
-      } else if (ufoeregrad === 100) {
-        // Bruker med 100 % uføretrygd har ikke fått steg om AFP og skal navigere tilbake forbi den
-        antallStepTilbake = antallStepTilbake + 1
-      } else if (loependeVedtak?.afpPrivat || loependeVedtak?.afpOffentlig) {
-        // Bruker med vedtak om AFP har ikke fått steg om AFP og skal navigere tilbake forbi den
-        antallStepTilbake = antallStepTilbake + 1
-      }
-    }
-
-    // Hvis brukeren er forbi ufoeretrygdAFP steget (gjelder både endring og vanlig flyt)
-    if (currentPathIndex > stepArrays.indexOf(paths.ufoeretrygdAFP)) {
-      // Bruker uten uføretrygd, eller bruker med uføretrygd som har svart "nei" på AFP,
-      // eller bruker med uføretrygd som ikke har fått AFP steget, har ikke fått ufoeretrygdAFP steget og skal navigere tilbake forbi den
-      if (!ufoeregrad || (ufoeregrad && (afp === null || afp === 'nei'))) {
-        antallStepTilbake = antallStepTilbake + 1
-      }
-    }
-
-    // Hvis brukeren er forbi samtykkeOffentligAFP steget (gjelder både endring og vanlig flyt)
-    if (currentPathIndex > stepArrays.indexOf(paths.samtykkeOffentligAFP)) {
-      // Bruker med uføretrygd eller brukere som har svart noe annet enn "ja_offentlig" på afp steget har ikke fått info steg om samtykkeOffentligAFP og skal navigere tilbake forbi den
-      if (ufoeregrad || afp !== 'ja_offentlig') {
-        antallStepTilbake = antallStepTilbake + 1
-      }
-    }
-
-    navigate(stepArrays[currentPathIndex - antallStepTilbake])
+    navigate({
+      pathname: stepArrays[currentPathIndex - 1],
+      search: createSearchParams({
+        back: 'true',
+      }).toString(),
+    })
   }
 
   const onStegvisningCancel = () => {

--- a/src/components/stegvisning/utils.ts
+++ b/src/components/stegvisning/utils.ts
@@ -1,7 +1,19 @@
+import {
+  paths,
+  stegvisningOrder,
+  stegvisningOrderEndring,
+} from '@/router/constants'
+
 export const STEGVISNING_FORM_NAMES = {
   afp: 'stegvisning-afp',
   samtykkeOffentligAFP: 'stegvisning-samtykke-offentlig-afp',
   samtykkePensjonsavtaler: 'stegvisning-samtykke-pensjonsavtaler',
   sivilstand: 'stegvisning-sivilstand',
   utenlandsopphold: 'stegvisning-utenlandsopphold',
+}
+
+export const getStepArrays = (
+  isEndring: boolean | undefined
+): Array<(typeof paths)[keyof typeof paths]> => {
+  return isEndring ? [...stegvisningOrderEndring] : [...stegvisningOrder]
 }

--- a/src/mocks/data/loepende-vedtak.json
+++ b/src/mocks/data/loepende-vedtak.json
@@ -1,4 +1,5 @@
 {
+  "harLoependeVedtak": false,
   "ufoeretrygd": {
     "grad": 0
   }

--- a/src/mocks/mockedRTKQueryApiCalls.ts
+++ b/src/mocks/mockedRTKQueryApiCalls.ts
@@ -434,7 +434,7 @@ export const fulfilledGetLoependeVedtakFremtidig = {
     requestId: 'xTaE6mOydr5ZI75UXq4Wi',
     startedTimeStamp: 1688046411971,
     data: {
-      harLoependeVedtak: false,
+      harLoependeVedtak: true,
       ufoeretrygd: {
         grad: 0,
       },

--- a/src/mocks/mockedRTKQueryApiCalls.ts
+++ b/src/mocks/mockedRTKQueryApiCalls.ts
@@ -434,7 +434,7 @@ export const fulfilledGetLoependeVedtakFremtidig = {
     requestId: 'xTaE6mOydr5ZI75UXq4Wi',
     startedTimeStamp: 1688046411971,
     data: {
-      harLoependeVedtak: true,
+      harLoependeVedtak: false,
       ufoeretrygd: {
         grad: 0,
       },

--- a/src/pages/StepAFP/__tests__/StepAFP.test.tsx
+++ b/src/pages/StepAFP/__tests__/StepAFP.test.tsx
@@ -306,7 +306,11 @@ describe('StepAFP', () => {
     await waitFor(async () => {
       await user.click(await screen.findByText('stegvisning.tilbake'))
     })
-    expect(navigateMock).toHaveBeenCalledWith(paths.utenlandsopphold)
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: expect.stringContaining('back=true') as string,
+      })
+    )
   })
 
   describe('Gitt at brukeren er logget på som veileder', async () => {

--- a/src/pages/StepSamtykkeOffentligAFP/__tests__/StepSamtykkeOffentligAFP.test.tsx
+++ b/src/pages/StepSamtykkeOffentligAFP/__tests__/StepSamtykkeOffentligAFP.test.tsx
@@ -86,7 +86,11 @@ describe('StepSamtykkeOffentligAFP', () => {
 
     await user.click(screen.getByText('stegvisning.tilbake'))
 
-    expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: expect.stringContaining('back=true') as string,
+      })
+    )
   })
 
   describe('Gitt at brukeren er logget på som veileder', async () => {

--- a/src/pages/StepSamtykkePensjonsavtaler/__tests__/StepSamtykkePensjonsavtaler.test.tsx
+++ b/src/pages/StepSamtykkePensjonsavtaler/__tests__/StepSamtykkePensjonsavtaler.test.tsx
@@ -104,7 +104,11 @@ describe('StepSamtykkePensjonsavtaler', () => {
     })
 
     await user.click(screen.getByText('stegvisning.tilbake'))
-    expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: expect.stringContaining('back=true') as string,
+      })
+    )
   })
 
   describe('Gitt at brukeren er logget på som veileder', async () => {

--- a/src/pages/StepUfoeretrygdAFP/__tests__/StepUfoeretrygdAFP.test.tsx
+++ b/src/pages/StepUfoeretrygdAFP/__tests__/StepUfoeretrygdAFP.test.tsx
@@ -61,7 +61,11 @@ describe('StepUfoeretrygdAFP', () => {
       },
     })
     await user.click(await screen.findByText('stegvisning.tilbake'))
-    expect(navigateMock).toHaveBeenCalledWith(paths.afp)
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: expect.stringContaining('back=true') as string,
+      })
+    )
   })
 
   describe('Gitt at brukeren er logget på som veileder', async () => {

--- a/src/pages/StepUtenlandsopphold/__tests__/StepUtenlandsopphold.test.tsx
+++ b/src/pages/StepUtenlandsopphold/__tests__/StepUtenlandsopphold.test.tsx
@@ -90,7 +90,7 @@ describe('StepUtenlandsopphold', () => {
     expect(navigateMock).toHaveBeenCalledWith(paths.afp)
   })
 
-  it('nullstiller input fra brukeren og navigerer tilbake til /sivilstand når brukeren klikker på Tilbake', async () => {
+  it('nullstiller input fra brukeren og navigerer når brukeren klikker på Tilbake', async () => {
     mockResponse('/v4/person', {
       status: 200,
       json: {
@@ -123,6 +123,10 @@ describe('StepUtenlandsopphold', () => {
     expect(radioButtons[0]).toBeChecked()
     await user.click(await screen.findByText('stegvisning.tilbake'))
     expect(store.getState().userInput.harUtenlandsopphold).toBeNull()
-    expect(navigateMock).toHaveBeenCalledWith(paths.sivilstand)
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: expect.stringContaining('back=true') as string,
+      })
+    )
   })
 })

--- a/src/router/__tests__/loaders.test.tsx
+++ b/src/router/__tests__/loaders.test.tsx
@@ -318,8 +318,8 @@ describe('Loaders', () => {
 
         mockResponse('/v4/vedtak/loepende-vedtak', {
           json: {
-            harLoependeVedtak: true,
             ufoeretrygd: { grad: 75 },
+            harLoependeVedtak: true,
           } satisfies LoependeVedtak,
         })
         mockResponse('/v4/person', {
@@ -362,8 +362,8 @@ describe('Loaders', () => {
 
         mockResponse('/v4/vedtak/loepende-vedtak', {
           json: {
-            harLoependeVedtak: true,
             ufoeretrygd: { grad: 75 },
+            harLoependeVedtak: true,
           } satisfies LoependeVedtak,
         })
         mockResponse('/v4/person', {

--- a/src/router/__tests__/loaders.test.tsx
+++ b/src/router/__tests__/loaders.test.tsx
@@ -68,7 +68,7 @@ describe('Loaders', () => {
       }
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
-      const returnedFromLoader = await landingPageAccessGuard()
+      const returnedFromLoader = landingPageAccessGuard()
       console.log('returnedFromLoader', returnedFromLoader)
       expectRedirectResponse(returnedFromLoader, paths.start)
     })

--- a/src/router/__tests__/loaders.test.tsx
+++ b/src/router/__tests__/loaders.test.tsx
@@ -1,4 +1,5 @@
 import { add, endOfDay, format } from 'date-fns'
+import { LoaderFunctionArgs } from 'react-router'
 import { describe, it, vi } from 'vitest'
 
 import {
@@ -45,6 +46,16 @@ function expectRedirectResponse(
   expect(returnedFromLoader.headers.get('location')).toBe(expectedLocation)
 }
 
+export function createMockRequest(
+  url = 'https://example.com'
+): LoaderFunctionArgs {
+  return {
+    request: new Request(url),
+    params: {},
+    context: {},
+  }
+}
+
 describe('Loaders', () => {
   afterEach(() => {
     store.dispatch(apiSliceUtils.apiSlice.util.resetApiState())
@@ -57,7 +68,8 @@ describe('Loaders', () => {
       }
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
-      const returnedFromLoader = landingPageAccessGuard()
+      const returnedFromLoader = await landingPageAccessGuard()
+      console.log('returnedFromLoader', returnedFromLoader)
       expectRedirectResponse(returnedFromLoader, paths.start)
     })
   })
@@ -277,7 +289,10 @@ describe('Loaders', () => {
         userInput: { ...userInputInitialState, samtykke: null },
       }))
 
-      expectRedirectResponse(await stepAFPAccessGuard(), '/start')
+      expectRedirectResponse(
+        await stepAFPAccessGuard(createMockRequest()),
+        '/start'
+      )
     })
 
     describe('Gitt at alle kallene er vellykket, ', () => {
@@ -288,7 +303,7 @@ describe('Loaders', () => {
         }
         store.getState = vi.fn().mockImplementation(() => mockedState)
 
-        const returnedFromLoader = stepAFPAccessGuard()
+        const returnedFromLoader = stepAFPAccessGuard(createMockRequest())
         await expect(returnedFromLoader).resolves.toMatchObject({
           loependeVedtak: { ufoeretrygd: { grad: 0 } },
         })
@@ -331,7 +346,7 @@ describe('Loaders', () => {
         }
         store.getState = vi.fn().mockImplementation(() => mockedState)
 
-        const returnedFromLoader = stepAFPAccessGuard()
+        const returnedFromLoader = stepAFPAccessGuard(createMockRequest())
         await expect(returnedFromLoader).resolves.toMatchObject({
           person: { foedselsdato },
           loependeVedtak: { ufoeretrygd: { grad: 75 } },
@@ -375,7 +390,10 @@ describe('Loaders', () => {
         }
         store.getState = vi.fn().mockImplementation(() => mockedState)
 
-        expectRedirectResponse(await stepAFPAccessGuard(), paths.ufoeretrygdAFP)
+        expectRedirectResponse(
+          await stepAFPAccessGuard(createMockRequest()),
+          paths.ufoeretrygdAFP
+        )
       })
 
       it('brukere med vedtak om afp-offentlig, er redirigert', async () => {
@@ -396,7 +414,10 @@ describe('Loaders', () => {
         }
         store.getState = vi.fn().mockImplementation(() => mockedState)
 
-        expectRedirectResponse(await stepAFPAccessGuard(), paths.ufoeretrygdAFP)
+        expectRedirectResponse(
+          await stepAFPAccessGuard(createMockRequest()),
+          paths.ufoeretrygdAFP
+        )
       })
 
       it('brukere med vedtak om afp-privat, er redirigert', async () => {
@@ -422,7 +443,10 @@ describe('Loaders', () => {
         }
         store.getState = vi.fn().mockImplementation(() => mockedState)
 
-        expectRedirectResponse(await stepAFPAccessGuard(), paths.ufoeretrygdAFP)
+        expectRedirectResponse(
+          await stepAFPAccessGuard(createMockRequest()),
+          paths.ufoeretrygdAFP
+        )
       })
 
       it('brukere med 100 % uføretrygd er redirigert', async () => {
@@ -448,7 +472,10 @@ describe('Loaders', () => {
         }
         store.getState = vi.fn().mockImplementation(() => mockedState)
 
-        expectRedirectResponse(await stepAFPAccessGuard(), paths.ufoeretrygdAFP)
+        expectRedirectResponse(
+          await stepAFPAccessGuard(createMockRequest()),
+          paths.ufoeretrygdAFP
+        )
       })
     })
 
@@ -483,7 +510,7 @@ describe('Loaders', () => {
       }
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
-      const returnedFromLoader = stepAFPAccessGuard()
+      const returnedFromLoader = stepAFPAccessGuard(createMockRequest())
       await expect(returnedFromLoader).resolves.not.toThrow()
       await expect(returnedFromLoader).resolves.toMatchObject({
         person: {
@@ -516,7 +543,7 @@ describe('Loaders', () => {
       }
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
-      const returnedFromLoader = stepAFPAccessGuard()
+      const returnedFromLoader = stepAFPAccessGuard(createMockRequest())
       // Når denne kaster så blir den fanget opp av ErrorBoundary som viser uventet feil
       await expect(returnedFromLoader).rejects.toThrow()
     })
@@ -551,7 +578,7 @@ describe('Loaders', () => {
       }
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
-      const returnedFromLoader = stepAFPAccessGuard()
+      const returnedFromLoader = stepAFPAccessGuard(createMockRequest())
       await expect(returnedFromLoader).resolves.not.toThrow()
     })
 
@@ -581,7 +608,7 @@ describe('Loaders', () => {
       }
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
-      const returnedFromLoader = stepAFPAccessGuard()
+      const returnedFromLoader = stepAFPAccessGuard(createMockRequest())
       await expect(returnedFromLoader).rejects.toThrow()
     })
 
@@ -617,7 +644,7 @@ describe('Loaders', () => {
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
       expectRedirectResponse(
-        await stepAFPAccessGuard(),
+        await stepAFPAccessGuard(createMockRequest()),
         `${paths.henvisning}/${henvisningUrlParams.apotekerne}`
       )
     })
@@ -653,7 +680,7 @@ describe('Loaders', () => {
       }
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
-      const returnedFromLoader = stepAFPAccessGuard()
+      const returnedFromLoader = stepAFPAccessGuard(createMockRequest())
       await expect(returnedFromLoader).resolves.not.toThrow()
     })
 
@@ -681,7 +708,7 @@ describe('Loaders', () => {
       }
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
-      const returnedFromLoader = stepAFPAccessGuard()
+      const returnedFromLoader = stepAFPAccessGuard(createMockRequest())
       await expect(returnedFromLoader).rejects.toThrow()
     })
   })
@@ -694,7 +721,10 @@ describe('Loaders', () => {
       }
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
-      expectRedirectResponse(await stepUfoeretrygdAFPAccessGuard(), paths.start)
+      expectRedirectResponse(
+        await stepUfoeretrygdAFPAccessGuard(createMockRequest()),
+        paths.start
+      )
     })
 
     it('Når brukeren ikke har uføretrygd, er hen redirigert', async () => {
@@ -705,7 +735,7 @@ describe('Loaders', () => {
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
       expectRedirectResponse(
-        await stepUfoeretrygdAFPAccessGuard(),
+        await stepUfoeretrygdAFPAccessGuard(createMockRequest()),
         paths.samtykkeOffentligAFP
       )
     })
@@ -725,7 +755,8 @@ describe('Loaders', () => {
         }
         store.getState = vi.fn().mockImplementation(() => mockedState)
 
-        const returnedFromLoader = await stepUfoeretrygdAFPAccessGuard()
+        const returnedFromLoader =
+          await stepUfoeretrygdAFPAccessGuard(createMockRequest())
         expect(returnedFromLoader).toBeUndefined()
       })
 
@@ -746,7 +777,7 @@ describe('Loaders', () => {
         })
 
         expectRedirectResponse(
-          await stepUfoeretrygdAFPAccessGuard(),
+          await stepUfoeretrygdAFPAccessGuard(createMockRequest()),
           paths.samtykkeOffentligAFP
         )
       })
@@ -766,7 +797,7 @@ describe('Loaders', () => {
         store.getState = vi.fn().mockImplementation(() => mockedState)
 
         expectRedirectResponse(
-          await stepUfoeretrygdAFPAccessGuard(),
+          await stepUfoeretrygdAFPAccessGuard(createMockRequest()),
           paths.samtykkeOffentligAFP
         )
       })
@@ -782,7 +813,7 @@ describe('Loaders', () => {
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
       expectRedirectResponse(
-        await stepSamtykkeOffentligAFPAccessGuard(),
+        await stepSamtykkeOffentligAFPAccessGuard(createMockRequest()),
         paths.start
       )
     })
@@ -797,7 +828,8 @@ describe('Loaders', () => {
       }
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
-      const returnedFromLoader = await stepSamtykkeOffentligAFPAccessGuard()
+      const returnedFromLoader =
+        await stepSamtykkeOffentligAFPAccessGuard(createMockRequest())
       expect(returnedFromLoader).toBeUndefined()
     })
 
@@ -818,7 +850,8 @@ describe('Loaders', () => {
       }
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
-      const returnedFromLoader = await stepSamtykkeOffentligAFPAccessGuard()
+      const returnedFromLoader =
+        await stepSamtykkeOffentligAFPAccessGuard(createMockRequest())
       expect(returnedFromLoader).toBeUndefined()
     })
 
@@ -833,7 +866,7 @@ describe('Loaders', () => {
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
       expectRedirectResponse(
-        await stepSamtykkeOffentligAFPAccessGuard(),
+        await stepSamtykkeOffentligAFPAccessGuard(createMockRequest()),
         paths.samtykke
       )
     })

--- a/src/router/__tests__/loaders.test.tsx
+++ b/src/router/__tests__/loaders.test.tsx
@@ -69,7 +69,6 @@ describe('Loaders', () => {
       store.getState = vi.fn().mockImplementation(() => mockedState)
 
       const returnedFromLoader = landingPageAccessGuard()
-      console.log('returnedFromLoader', returnedFromLoader)
       expectRedirectResponse(returnedFromLoader, paths.start)
     })
   })

--- a/src/router/loaders.tsx
+++ b/src/router/loaders.tsx
@@ -55,14 +55,10 @@ export interface AuthenticationGuardData {
   authResponse: Response
 }
 
-export const authenticationGuard: SafeLoaderFunction<
-  AuthenticationGuardData
-> = async () => {
+export const authenticationGuard = async () => {
   const authResponse = await fetch(`${HOST_BASEURL}/oauth2/session`)
   return { authResponse }
 }
-
-export type DirectAccessGuardData = void
 
 export const directAccessGuard = (): Response | undefined => {
   const state = store.getState()
@@ -78,11 +74,7 @@ export const directAccessGuard = (): Response | undefined => {
 
 ////////////////////////////////////////////////////////////////////////
 
-export type LandingPageAccessGuardData = void
-
-export const landingPageAccessGuard: SafeLoaderFunction<
-  LandingPageAccessGuardData
-> = async () => {
+export const landingPageAccessGuard = async () => {
   const isVeileder = selectIsVeileder(store.getState())
   if (isVeileder) {
     return redirect(paths.start)
@@ -352,7 +344,7 @@ export const stepSamtykkeOffentligAFPAccessGuard = async ({
 
   // Bruker uten uføretrygd som svarer ja_offentlig til AFP kan se steget
   if (showStep) {
-    return { data: undefined }
+    return
   }
 
   const stepArrays = isLoependeVedtakEndring(loependeVedtak)

--- a/src/router/loaders.tsx
+++ b/src/router/loaders.tsx
@@ -1,6 +1,6 @@
 import { SerializedError } from '@reduxjs/toolkit'
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query'
-import { redirect } from 'react-router'
+import { LoaderFunctionArgs, redirect } from 'react-router'
 
 import { HOST_BASEURL } from '@/paths'
 import {
@@ -18,6 +18,11 @@ import {
 } from '@/utils/alder'
 import { isLoependeVedtakEndring } from '@/utils/loependeVedtak'
 import { logger } from '@/utils/logging'
+import { skip } from '@/utils/navigation'
+
+export type SafeLoaderFunction<T> = (
+  args: LoaderFunctionArgs
+) => Promise<T | Response>
 
 export type Reason =
   | 'INSUFFICIENT_LEVEL_OF_ASSURANCE'
@@ -46,12 +51,20 @@ export interface LoginContext {
   isLoggedIn: boolean
 }
 
-export async function authenticationGuard() {
+export interface AuthenticationGuardData {
+  authResponse: Response
+}
+
+export const authenticationGuard: SafeLoaderFunction<
+  AuthenticationGuardData
+> = async () => {
   const authResponse = await fetch(`${HOST_BASEURL}/oauth2/session`)
   return { authResponse }
 }
 
-export const directAccessGuard = () => {
+export type DirectAccessGuardData = void
+
+export const directAccessGuard = (): Response | undefined => {
   const state = store.getState()
   // Dersom ingen kall er registrert i store betyr det at brukeren prøver å aksessere en url direkte
   if (
@@ -60,15 +73,21 @@ export const directAccessGuard = () => {
   ) {
     return redirect(paths.start)
   }
+  return undefined
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-export const landingPageAccessGuard = () => {
+export type LandingPageAccessGuardData = void
+
+export const landingPageAccessGuard: SafeLoaderFunction<
+  LandingPageAccessGuardData
+> = async () => {
   const isVeileder = selectIsVeileder(store.getState())
   if (isVeileder) {
     return redirect(paths.start)
   }
+  return Promise.resolve(undefined)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -232,7 +251,7 @@ export const stepSivilstandAccessGuard = async () => {
 
 ////////////////////////////////////////////////////////////////////////
 
-export const stepAFPAccessGuard = async () => {
+export const stepAFPAccessGuard = async ({ request }: LoaderFunctionArgs) => {
   if (directAccessGuard()) {
     return redirect(paths.start)
   }
@@ -279,7 +298,7 @@ export const stepAFPAccessGuard = async () => {
       person.foedselsdato &&
       isFoedselsdatoOverAlder(person.foedselsdato, AFP_UFOERE_OPPSIGELSESALDER))
   ) {
-    return redirect(stepArrays[stepArrays.indexOf(paths.afp) + 1])
+    return skip(stepArrays, paths.afp, request)
   } else {
     return {
       person,
@@ -290,7 +309,9 @@ export const stepAFPAccessGuard = async () => {
 
 ///////////////////////////////////////////////////////////////////////////
 
-export const stepUfoeretrygdAFPAccessGuard = async () => {
+export const stepUfoeretrygdAFPAccessGuard = async ({
+  request,
+}: LoaderFunctionArgs) => {
   if (directAccessGuard()) {
     return redirect(paths.start)
   }
@@ -310,18 +331,20 @@ export const stepUfoeretrygdAFPAccessGuard = async () => {
   if (showStep) {
     return
   }
-  return redirect(stepArrays[stepArrays.indexOf(paths.ufoeretrygdAFP) + 1])
+  return skip(stepArrays, paths.ufoeretrygdAFP, request)
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-export const stepSamtykkeOffentligAFPAccessGuard = async () => {
+export const stepSamtykkeOffentligAFPAccessGuard = async ({
+  request,
+}: LoaderFunctionArgs) => {
   if (directAccessGuard()) {
     return redirect(paths.start)
   }
 
-  const state = store.getState()
-  const afp = selectAfp(state)
+  const appState = store.getState()
+  const afp = selectAfp(appState)
   const loependeVedtak = await store
     .dispatch(apiSlice.endpoints.getLoependeVedtak.initiate())
     .unwrap()
@@ -329,16 +352,14 @@ export const stepSamtykkeOffentligAFPAccessGuard = async () => {
 
   // Bruker uten uføretrygd som svarer ja_offentlig til AFP kan se steget
   if (showStep) {
-    return
+    return { data: undefined }
   }
 
   const stepArrays = isLoependeVedtakEndring(loependeVedtak)
     ? stegvisningOrderEndring
     : stegvisningOrder
 
-  return redirect(
-    stepArrays[stepArrays.indexOf(paths.samtykkeOffentligAFP) + 1]
-  )
+  return skip(stepArrays, paths.samtykkeOffentligAFP, request)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/router/loaders.tsx
+++ b/src/router/loaders.tsx
@@ -74,12 +74,11 @@ export const directAccessGuard = (): Response | undefined => {
 
 ////////////////////////////////////////////////////////////////////////
 
-export const landingPageAccessGuard = async () => {
+export const landingPageAccessGuard = () => {
   const isVeileder = selectIsVeileder(store.getState())
   if (isVeileder) {
     return redirect(paths.start)
   }
-  return Promise.resolve(undefined)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/utils/__tests__/navigation.test.ts
+++ b/src/utils/__tests__/navigation.test.ts
@@ -1,0 +1,45 @@
+import { redirect } from 'react-router'
+
+import { skip } from '../navigation'
+
+describe('navigation-utils', () => {
+  describe('skip', () => {
+    const stepArrays = ['step1', 'step2', 'step3', 'step4'] as const
+
+    it('omdirigerer til neste step når man går fremover', () => {
+      const currentPath = 'step2'
+      const request = new Request('https://example.com/step2')
+
+      const result = skip(stepArrays, currentPath, request)
+
+      expect(result).toEqual(redirect('step3'))
+    })
+
+    it('omdirigerer til forrige step når man går bakover', () => {
+      const currentPath = 'step3'
+      const request = new Request('https://example.com/step3?back=true')
+
+      const result = skip(stepArrays, currentPath, request)
+
+      expect(result).toEqual(redirect('step2?back=true'))
+    })
+
+    it('omdirigerer til første step hvis gjeldende sti ikke er i step-arrayet', () => {
+      const currentPath = 'unknown'
+      const request = new Request('https://example.com/unknown')
+
+      const result = skip(stepArrays, currentPath, request)
+
+      expect(result).toEqual(redirect('step1'))
+    })
+
+    it('omdirigerer til første step hvis step-indeksen er utenfor rekkevidde', () => {
+      const currentPath = 'step1'
+      const request = new Request('https://example.com/step1?back=true')
+
+      const result = skip(stepArrays, currentPath, request)
+
+      expect(result).toEqual(redirect('step1'))
+    })
+  })
+})

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,46 @@
+import { redirect } from 'react-router'
+
+/**
+ * Skip funksjon for access guards
+ *
+ * Denne funksjonen bestemmer om det skal hoppes til neste eller forrige steg
+ * basert på navigasjonsretning lagret i sessionStorage.
+ *
+ * @param stepArrays - Array med stier i stegsekvensen
+ * @param currentPath - Gjeldende sti som skal hoppes over
+ * @returns En redirect respons til passende neste/forrige steg
+ */
+export const skip = (
+  stepArrays: readonly string[],
+  currentPath: string,
+  request: Request
+) => {
+  const currentIndex = stepArrays.indexOf(currentPath)
+  if (currentIndex === -1) {
+    // Sti ikke funnet i stegene
+    return redirect(stepArrays[0])
+  }
+
+  const isBackwardNavigation =
+    new URL(request.url).searchParams.get('back') === 'true'
+
+  const redirectIndex = isBackwardNavigation
+    ? currentIndex - 1
+    : currentIndex + 1
+
+  // Sjekk at redirect-indeksen er innenfor grensene
+  if (redirectIndex < 0 || redirectIndex >= stepArrays.length) {
+    return redirect(stepArrays[0])
+  }
+
+  // Opprett redirect URL
+  const redirectPath = stepArrays[redirectIndex]
+
+  // Returner redirect og behold navigasjonsretningen
+  // ved å inkludere 'back' query parameter ved bakovernavigasjon
+  return redirect(
+    isBackwardNavigation 
+      ? `${redirectPath}?back=true` 
+      : redirectPath
+  )
+}

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -39,8 +39,6 @@ export const skip = (
   // Returner redirect og behold navigasjonsretningen
   // ved å inkludere 'back' query parameter ved bakovernavigasjon
   return redirect(
-    isBackwardNavigation 
-      ? `${redirectPath}?back=true` 
-      : redirectPath
+    isBackwardNavigation ? `${redirectPath}?back=true` : redirectPath
   )
 }

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -3,8 +3,7 @@ import { redirect } from 'react-router'
 /**
  * Skip funksjon for access guards
  *
- * Denne funksjonen bestemmer om det skal hoppes til neste eller forrige steg
- * basert på navigasjonsretning lagret i sessionStorage.
+ * Denne funksjonen bestemmer om det skal hoppes til neste eller forrige steg basert på query parameter 'back'
  *
  * @param stepArrays - Array med stier i stegsekvensen
  * @param currentPath - Gjeldende sti som skal hoppes over


### PR DESCRIPTION
Forbedrer navigasjonssystemet i stegvisning ved å implementere en ny metode for å bevare navigasjonsretningen i applikasjonen. Navigasjonsretningen lagres nå i URL-en ved hjelp av en query-parameter (`back=true`) som gjør det mulig å skille mellom framover- og bakovernavigering.

Introduserer en ny `skip`-funksjon som håndterer omdirigering basert på navigasjonsretningen og oppdaterer alle loader-funksjoner til å bruke denne. Testene er oppdatert for å verifisere korrekt navigasjonsadferd.