### PR TITLE
Mock NAV dekoratøren for å hindre timeouts

### DIFF
--- a/src/context/LanguageProvider/__tests__/LanguageProvider.test.tsx
+++ b/src/context/LanguageProvider/__tests__/LanguageProvider.test.tsx
@@ -12,16 +12,6 @@ import { sanityClient } from '@/utils/sanity'
 import { setupStore } from '../../../state/store'
 import { LanguageProvider } from '../LanguageProvider'
 
-// Mock the nav decorator modules to prevent timeout issues
-vi.mock('@navikt/nav-dekoratoren-moduler', () => ({
-  onLanguageSelect: vi.fn((callback) => {
-    // Store the callback but don't set up any listeners or timeouts
-    return vi.fn()
-  }),
-  setAvailableLanguages: vi.fn(),
-  getAmplitudeInstance: vi.fn(() => vi.fn()),
-}))
-
 function TestComponent() {
   const intl = useIntl()
   const { forbeholdAvsnittData, guidePanelData, readMoreData } =

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -49,6 +49,8 @@ vi.mock(
     return {
       ...mod.default,
       getAmplitudeInstance: () => vi.fn(),
+      onLanguageSelect: vi.fn(() => vi.fn()),
+      setAvailableLanguages: vi.fn(),
     }
   }
 )


### PR DESCRIPTION
* Potensiell fix for timeout issues vi noen ganger får på language provider:
![image](https://github.com/user-attachments/assets/641636ae-bbdf-4534-95cd-b93f235e0a79)

