### PR TITLE
Feature/PEK-1321 Justere UI for maanedsvisning i avansert beregning

### DIFF
--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.module.scss
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.module.scss
@@ -1,14 +1,15 @@
 @use '../../../../scss/variables';
 
 .container {
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0 var(--a-spacing-2);
   width: 100%;
 }
 
 .row {
   th,
   td {
-    padding: 0;
+    padding: 0 0 0 var(--a-spacing-3);
     text-align: left;
     font-size: var(--a-font-size-large);
   }
@@ -23,6 +24,22 @@
   td {
     text-align: right;
     white-space: nowrap;
+  }
+}
+
+.afpMetric {
+  border-left: var(--a-spacing-1-alt) solid transparent;
+
+  &__blue {
+    border-color: var(--a-deepblue-500);
+  }
+
+  &__purple {
+    border-color: var(--a-purple-400);
+  }
+
+  &__green {
+    border-color: var(--a-data-surface-5);
   }
 }
 

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.module.scss
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.module.scss
@@ -19,6 +19,10 @@
     td {
       font-size: var(--a-font-size-medium);
     }
+
+    th.noGradering {
+      padding: 0;
+    }
   }
 
   td {
@@ -28,7 +32,7 @@
 }
 
 @media screen and (min-width: variables.$a-breakpoint-sm) {
-  .afpMetric {
+  .monthlyPayoutElement {
     box-sizing: border-box;
     border-left: var(--a-spacing-1-alt) solid transparent;
 
@@ -51,5 +55,9 @@
 
   * {
     font-weight: var(--a-font-weight-bold);
+  }
+
+  th {
+    padding: 0;
   }
 }

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.module.scss
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.module.scss
@@ -27,19 +27,22 @@
   }
 }
 
-.afpMetric {
-  border-left: var(--a-spacing-1-alt) solid transparent;
+@media screen and (min-width: variables.$a-breakpoint-sm) {
+  .afpMetric {
+    box-sizing: border-box;
+    border-left: var(--a-spacing-1-alt) solid transparent;
 
-  &__blue {
-    border-color: var(--a-deepblue-500);
-  }
+    &__blue {
+      border-color: var(--a-deepblue-500);
+    }
 
-  &__purple {
-    border-color: var(--a-purple-400);
-  }
+    &__purple {
+      border-color: var(--a-purple-400);
+    }
 
-  &__green {
-    border-color: var(--a-data-surface-5);
+    &__green {
+      border-color: var(--a-data-surface-5);
+    }
   }
 }
 

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.module.scss
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.module.scss
@@ -2,8 +2,12 @@
 
 .container {
   border-collapse: separate;
-  border-spacing: 0 var(--a-spacing-2);
+  border-spacing: 0;
   width: 100%;
+
+  @media screen and (min-width: variables.$a-breakpoint-sm) {
+    border-spacing: 0 var(--a-spacing-2);
+  }
 }
 
 .row {

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.module.scss.d.ts
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.module.scss.d.ts
@@ -1,11 +1,11 @@
 declare const classNames: {
   readonly container: "container";
-  readonly row: "row";
-  readonly noGradering: "noGradering";
   readonly monthlyPayoutElement: "monthlyPayoutElement";
   readonly monthlyPayoutElement__blue: "monthlyPayoutElement__blue";
   readonly monthlyPayoutElement__purple: "monthlyPayoutElement__purple";
   readonly monthlyPayoutElement__green: "monthlyPayoutElement__green";
+  readonly row: "row";
+  readonly noGradering: "noGradering";
   readonly sum: "sum";
 };
 export = classNames;

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.module.scss.d.ts
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.module.scss.d.ts
@@ -1,10 +1,11 @@
 declare const classNames: {
   readonly container: "container";
   readonly row: "row";
-  readonly afpMetric: "afpMetric";
-  readonly afpMetric__blue: "afpMetric__blue";
-  readonly afpMetric__purple: "afpMetric__purple";
-  readonly afpMetric__green: "afpMetric__green";
+  readonly noGradering: "noGradering";
+  readonly monthlyPayoutElement: "monthlyPayoutElement";
+  readonly monthlyPayoutElement__blue: "monthlyPayoutElement__blue";
+  readonly monthlyPayoutElement__purple: "monthlyPayoutElement__purple";
+  readonly monthlyPayoutElement__green: "monthlyPayoutElement__green";
   readonly sum: "sum";
 };
 export = classNames;

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.module.scss.d.ts
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.module.scss.d.ts
@@ -1,6 +1,10 @@
 declare const classNames: {
   readonly container: "container";
   readonly row: "row";
+  readonly afpMetric: "afpMetric";
+  readonly afpMetric__blue: "afpMetric__blue";
+  readonly afpMetric__purple: "afpMetric__purple";
+  readonly afpMetric__green: "afpMetric__green";
   readonly sum: "sum";
 };
 export = classNames;

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.tsx
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.tsx
@@ -15,12 +15,14 @@ interface Props {
   pensjonsdata: Pensjonsdata
   summerYtelser: (data: Pensjonsdata) => number
   hentUttaksMaanedOgAar: (alder: Alder) => string
+  harGradering?: boolean
 }
 
 export const PensjonDataVisning: React.FC<Props> = ({
   pensjonsdata,
   summerYtelser,
   hentUttaksMaanedOgAar,
+  harGradering,
 }) => {
   const intl = useIntl()
   const {
@@ -51,7 +53,11 @@ export const PensjonDataVisning: React.FC<Props> = ({
           <tr className={styles.row}>
             <th
               scope="row"
-              className={clsx(styles.afpMetric, styles.afpMetric__purple)}
+              className={clsx(
+                styles.monthlyPayoutElement,
+                styles.monthlyPayoutElement__purple,
+                !harGradering && styles.noGradering
+              )}
             >
               <BodyLong>
                 <FormattedMessage id="beregning.avansert.maanedsbeloep.afp" />:
@@ -69,7 +75,11 @@ export const PensjonDataVisning: React.FC<Props> = ({
           <tr className={styles.row}>
             <th
               scope="row"
-              className={clsx(styles.afpMetric, styles.afpMetric__green)}
+              className={clsx(
+                styles.monthlyPayoutElement,
+                styles.monthlyPayoutElement__green,
+                !harGradering && styles.noGradering
+              )}
             >
               <BodyLong>
                 <FormattedMessage id="beregning.avansert.maanedsbeloep.pensjonsavtaler" />
@@ -86,7 +96,11 @@ export const PensjonDataVisning: React.FC<Props> = ({
           <tr className={styles.row}>
             <th
               scope="row"
-              className={clsx(styles.afpMetric, styles.afpMetric__blue)}
+              className={clsx(
+                styles.monthlyPayoutElement,
+                styles.monthlyPayoutElement__blue,
+                !harGradering && styles.noGradering
+              )}
             >
               <BodyLong>
                 <FormattedMessage
@@ -107,7 +121,10 @@ export const PensjonDataVisning: React.FC<Props> = ({
             className={clsx(styles.row, styles.sum)}
             data-testid="maanedsbeloep-avansert-sum"
           >
-            <th scope="row">
+            <th
+              scope="row"
+              className={clsx(!harGradering && styles.noGradering)}
+            >
               <BodyLong>
                 <FormattedMessage
                   id="beregning.avansert.maanedsbeloep.sum"

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.tsx
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonDataVisning.tsx
@@ -49,7 +49,10 @@ export const PensjonDataVisning: React.FC<Props> = ({
       <tbody>
         {harAFP && (
           <tr className={styles.row}>
-            <th scope="row">
+            <th
+              scope="row"
+              className={clsx(styles.afpMetric, styles.afpMetric__purple)}
+            >
               <BodyLong>
                 <FormattedMessage id="beregning.avansert.maanedsbeloep.afp" />:
               </BodyLong>
@@ -64,7 +67,10 @@ export const PensjonDataVisning: React.FC<Props> = ({
 
         {pensjonsavtale > 0 && (
           <tr className={styles.row}>
-            <th scope="row">
+            <th
+              scope="row"
+              className={clsx(styles.afpMetric, styles.afpMetric__green)}
+            >
               <BodyLong>
                 <FormattedMessage id="beregning.avansert.maanedsbeloep.pensjonsavtaler" />
                 :
@@ -78,7 +84,10 @@ export const PensjonDataVisning: React.FC<Props> = ({
 
         {alderspensjon && (
           <tr className={styles.row}>
-            <th scope="row">
+            <th
+              scope="row"
+              className={clsx(styles.afpMetric, styles.afpMetric__blue)}
+            >
               <BodyLong>
                 <FormattedMessage
                   id="beregning.avansert.maanedsbeloep.alderspensjon"

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.module.scss
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.module.scss
@@ -1,11 +1,11 @@
 @use '../../../../scss/variables';
 
-.desktopDivider {
+.dividerWrapper {
   display: none;
 }
 
 @media screen and (min-width: variables.$a-breakpoint-lg) {
-  .desktopDivider {
+  .dividerWrapper {
     display: block;
   }
 }

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.module.scss
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.module.scss
@@ -1,0 +1,11 @@
+@use '../../../../scss/variables';
+
+.desktopDivider {
+  display: none;
+}
+
+@media screen and (min-width: variables.$a-breakpoint-lg) {
+  .desktopDivider {
+    display: block;
+  }
+}

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.module.scss.d.ts
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.module.scss.d.ts
@@ -1,0 +1,4 @@
+declare const classNames: {
+  readonly desktopDivider: "desktopDivider";
+};
+export = classNames;

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.module.scss.d.ts
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.module.scss.d.ts
@@ -1,4 +1,4 @@
 declare const classNames: {
-  readonly desktopDivider: "desktopDivider";
+  readonly dividerWrapper: "dividerWrapper";
 };
 export = classNames;

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.tsx
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.tsx
@@ -3,6 +3,7 @@ import { useIntl } from 'react-intl'
 
 import { Box, HStack, Heading, VStack } from '@navikt/ds-react'
 
+import { Divider } from '@/components/common/Divider'
 import {
   UTTAKSALDER_FOR_AP_VED_PRE2025_OFFENTLIG_AFP,
   formatUttaksalder,
@@ -10,6 +11,8 @@ import {
 
 import { Pensjonsdata } from '../hooks'
 import { PensjonDataVisning } from './PensjonDataVisning'
+
+import styles from './PensjonVisningDesktop.module.scss'
 
 interface Props {
   pensjonsdata: Pensjonsdata[]
@@ -47,13 +50,17 @@ export const PensjonVisningDesktop: React.FC<Props> = ({
           <Box
             key={`desktop-${index}`}
             borderRadius="medium"
-            paddingInline="6"
+            paddingInline="0 6"
             paddingBlock="4"
             maxWidth={{ sm: '27rem', md: '31rem' }}
             flexGrow="1"
             height="fit-content"
           >
             <VStack gap="1">
+              <div className={styles.desktopDivider}>
+                <Divider smallMargin />
+              </div>
+
               <Heading
                 size="xsmall"
                 level="4"
@@ -75,6 +82,9 @@ export const PensjonVisningDesktop: React.FC<Props> = ({
                 summerYtelser={summerYtelser}
                 hentUttaksMaanedOgAar={hentUttaksmaanedOgAar}
               />
+              <div className={styles.desktopDivider}>
+                <Divider smallMargin />
+              </div>
             </VStack>
           </Box>
         )

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.tsx
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.tsx
@@ -32,7 +32,7 @@ export const PensjonVisningDesktop: React.FC<Props> = ({
   if (!pensjonsdata.length) return null
 
   return (
-    <HStack gap="4 8" width="100%" marginBlock="2 0">
+    <HStack gap="4 12" width="100%" marginBlock="2 0">
       {pensjonsdata.map((data, index) => {
         const isKapittel20AldersPensjon =
           data.alderspensjon &&

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.tsx
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.tsx
@@ -18,12 +18,14 @@ interface Props {
   pensjonsdata: Pensjonsdata[]
   summerYtelser: (data: Pensjonsdata) => number
   hentUttaksmaanedOgAar: (alder: Alder) => string
+  harGradering?: boolean
 }
 
 export const PensjonVisningDesktop: React.FC<Props> = ({
   pensjonsdata,
   summerYtelser,
   hentUttaksmaanedOgAar,
+  harGradering,
 }) => {
   const intl = useIntl()
 
@@ -51,14 +53,14 @@ export const PensjonVisningDesktop: React.FC<Props> = ({
             key={`desktop-${index}`}
             borderRadius="medium"
             paddingInline="0 6"
-            paddingBlock="4"
+            paddingBlock="4 0"
             maxWidth={{ sm: '27rem', md: '31rem' }}
             flexGrow="1"
             height="fit-content"
           >
             <VStack gap="1">
-              <div className={styles.desktopDivider}>
-                <Divider smallMargin />
+              <div className={styles.dividerWrapper}>
+                <Divider mediumMargin noMarginTop />
               </div>
 
               <Heading
@@ -81,9 +83,10 @@ export const PensjonVisningDesktop: React.FC<Props> = ({
                 pensjonsdata={data}
                 summerYtelser={summerYtelser}
                 hentUttaksMaanedOgAar={hentUttaksmaanedOgAar}
+                harGradering={harGradering}
               />
-              <div className={styles.desktopDivider}>
-                <Divider smallMargin />
+              <div className={styles.dividerWrapper}>
+                <Divider mediumMargin noMarginBottom />
               </div>
             </VStack>
           </Box>

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.tsx
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningDesktop.tsx
@@ -49,7 +49,6 @@ export const PensjonVisningDesktop: React.FC<Props> = ({
             borderRadius="medium"
             paddingInline="6"
             paddingBlock="4"
-            background="bg-subtle"
             maxWidth={{ sm: '27rem', md: '31rem' }}
             flexGrow="1"
             height="fit-content"

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningMobil.tsx
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningMobil.tsx
@@ -40,7 +40,7 @@ export const PensjonVisningMobil: React.FC<Props> = ({
   }
 
   return (
-    <Box marginBlock="2 0" borderRadius="medium" padding="3">
+    <Box marginBlock="2 0" borderRadius="medium">
       <VStack gap="2">
         {pensjonsdata.map((data, index) => {
           const isKapittel20AP =

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningMobil.tsx
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/Felles/PensjonVisningMobil.tsx
@@ -40,12 +40,7 @@ export const PensjonVisningMobil: React.FC<Props> = ({
   }
 
   return (
-    <Box
-      marginBlock="2 0"
-      borderRadius="medium"
-      padding="3"
-      background="bg-subtle"
-    >
+    <Box marginBlock="2 0" borderRadius="medium" padding="3">
       <VStack gap="2">
         {pensjonsdata.map((data, index) => {
           const isKapittel20AP =

--- a/src/components/Simulering/MaanedsbeloepAvansertBeregning/MaanedsbeloepAvansertBeregning.tsx
+++ b/src/components/Simulering/MaanedsbeloepAvansertBeregning/MaanedsbeloepAvansertBeregning.tsx
@@ -41,6 +41,7 @@ export const MaanedsbeloepAvansertBeregning: React.FC<Props> = (props) => {
           pensjonsdata={pensjonsdata}
           summerYtelser={summerYtelser}
           hentUttaksmaanedOgAar={hentUttaksmaanedOgAar}
+          harGradering={harGradering}
         />
       </div>
 

--- a/src/components/common/Divider/Divider.module.scss
+++ b/src/components/common/Divider/Divider.module.scss
@@ -8,11 +8,19 @@
     margin: var(--a-spacing-4) 0;
   }
 
+  &__mediumMargin {
+    margin: var(--a-spacing-6) 0;
+  }
+
   &__noMargin {
     margin: 0;
   }
 
   &__noMarginBottom {
     margin-bottom: 0;
+  }
+
+  &__noMarginTop {
+    margin-top: 0;
   }
 }

--- a/src/components/common/Divider/Divider.module.scss.d.ts
+++ b/src/components/common/Divider/Divider.module.scss.d.ts
@@ -1,7 +1,9 @@
 declare const classNames: {
   readonly divider: "divider";
   readonly divider__smallMargin: "divider__smallMargin";
+  readonly divider__mediumMargin: "divider__mediumMargin";
   readonly divider__noMargin: "divider__noMargin";
   readonly divider__noMarginBottom: "divider__noMarginBottom";
+  readonly divider__noMarginTop: "divider__noMarginTop";
 };
 export = classNames;

--- a/src/components/common/Divider/Divider.tsx
+++ b/src/components/common/Divider/Divider.tsx
@@ -4,16 +4,26 @@ import styles from './Divider.module.scss'
 
 interface Props {
   smallMargin?: boolean
+  mediumMargin?: boolean
   noMargin?: boolean
   noMarginBottom?: boolean
+  noMarginTop?: boolean
 }
 
-export const Divider = ({ smallMargin, noMargin, noMarginBottom }: Props) => (
+export const Divider = ({
+  smallMargin,
+  mediumMargin,
+  noMargin,
+  noMarginBottom,
+  noMarginTop,
+}: Props) => (
   <hr
     className={clsx(styles.divider, {
       [styles.divider__smallMargin]: smallMargin,
+      [styles.divider__mediumMargin]: mediumMargin,
       [styles.divider__noMargin]: noMargin,
       [styles.divider__noMarginBottom]: noMarginBottom,
+      [styles.divider__noMarginTop]: noMarginTop,
     })}
   />
 )


### PR DESCRIPTION
[PEK-1321](https://jira.adeo.no/browse/PEK-1321)
[Figma skisser](https://www.figma.com/design/hrlwP06CbWZWInsOclZ1cf/Beregning-2.0?node-id=1148-28852&t=U0071iUKkKm6Pfxj-0)

### Uten gradering:
<details> 
<summary>Before</summary>

<img width="617" alt="Screenshot 2025-06-23 at 22 37 41" src="https://github.com/user-attachments/assets/1a89b654-2f8f-428a-bb6f-847bef524784" />

</details>

<details>
<summary> After </summary>

https://github.com/user-attachments/assets/5863a915-9d21-4e8f-a8e7-8314139915e0

</details>

### Med gradering:

<details>
<summary> Before </summary>

<img width="756" alt="Screenshot 2025-06-23 at 22 41 32" src="https://github.com/user-attachments/assets/5353d059-7a92-4e99-a296-dcde42ba38e1" />

</details>

<details>
<summary> After </summary>

https://github.com/user-attachments/assets/af754ac9-36a9-4225-ad74-a8c5f8fe7736

</details>

