### PR TITLE
PEK-1364: Forhindre at useAppSelector hook settes opp flere ganger i AlderspensjonDetaljerGrunnlag

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "vite",
-    "start:q2": "concurrently \"NODE_ENV=production npm run start\" \"nodemon --watch server/ --exec 'npm run build:server && NODE_ENV=development node dist/server/server.js'\"",
+    "start:q2": "concurrently \"NODE_ENV=development npm run start\" \"nodemon --watch server/ --exec 'npm run build:server && NODE_ENV=development node dist/server/server.js'\"",
     "start:production": "vite --mode production",
     "sanity-dev": "sanity dev -- --port 3333",
     "sanity-start": "sanity start dist-sanity/",

--- a/src/components/Simulering/BeregningsdetaljerForOvergangskull/AlderspensjonDetaljerGrunnlag.tsx
+++ b/src/components/Simulering/BeregningsdetaljerForOvergangskull/AlderspensjonDetaljerGrunnlag.tsx
@@ -19,6 +19,10 @@ export const AlderspensjonDetaljerGrunnlag: React.FC<Props> = ({
   alderspensjonDetaljerListe,
   hasPre2025OffentligAfpUttaksalder,
 }) => {
+  const { uttaksalder, gradertUttaksperiode } = useAppSelector(
+    selectCurrentSimulation
+  )
+
   const renderDetaljer = (
     alderspensjonDetaljForValgtUttak: AlderspensjonDetaljerListe
   ) => (
@@ -43,15 +47,13 @@ export const AlderspensjonDetaljerGrunnlag: React.FC<Props> = ({
   )
 
   function renderHeading(index: number = 0) {
-    const { uttaksalder, gradertUttaksperiode } = useAppSelector(
-      selectCurrentSimulation
-    )
     const isGradertUttak = Boolean(
       gradertUttaksperiode &&
         !hasPre2025OffentligAfpUttaksalder &&
         gradertUttaksperiode?.uttaksalder.aar !== uttaksalder?.aar &&
         gradertUttaksperiode.grad > 0
     )
+
     return index === 0 && isGradertUttak ? (
       <Heading size="small" level="4">
         <FormattedMessage


### PR DESCRIPTION
Flytter useAppSelector-kallet fra renderHeading-funksjonen til komponent-nivå for å sikre konsistent hook rekkefølge. Dette løser React-feilen som oppstår når hooks ikke kalles i samme rekkefølge ved hver rendering. 
