### PR TITLE
Legg til benevning på beregningsdetaljer

### DIFF
--- a/src/components/Simulering/BeregningsdetaljerForOvergangskull/Felles/__tests__/AfpDetaljer.test.tsx
+++ b/src/components/Simulering/BeregningsdetaljerForOvergangskull/Felles/__tests__/AfpDetaljer.test.tsx
@@ -80,10 +80,10 @@ describe('Gitt at AfpDetaljer rendres', () => {
   ]
 
   const mockPre2025OffentligAfpData: DetaljRad[] = [
-    { tekst: 'AFP grad', verdi: 100 },
-    { tekst: 'Sluttpoengtall', verdi: 6.5 },
-    { tekst: 'Poengår', verdi: 35 },
-    { tekst: 'Trygdetid', verdi: 40 },
+    { tekst: 'AFP grad', verdi: '100 %' },
+    { tekst: 'Sluttpoengtall', verdi: '6.5' },
+    { tekst: 'Poengår', verdi: '35 år' },
+    { tekst: 'Trygdetid', verdi: '40 år' },
   ]
 
   const mockAfpOffentligData: DetaljRad[] = [
@@ -186,13 +186,13 @@ describe('Gitt at AfpDetaljer rendres', () => {
     )
 
     expect(screen.getByText('AFP grad:')).toBeVisible()
-    expect(screen.getByText('100')).toBeVisible()
+    expect(screen.getByText('100 %')).toBeVisible()
     expect(screen.getByText('Sluttpoengtall:')).toBeVisible()
     expect(screen.getByText('6.5')).toBeVisible()
     expect(screen.getByText('Poengår:')).toBeVisible()
-    expect(screen.getByText('35')).toBeVisible()
+    expect(screen.getByText('35 år')).toBeVisible()
     expect(screen.getByText('Trygdetid:')).toBeVisible()
-    expect(screen.getByText('40')).toBeVisible()
+    expect(screen.getByText('40 år')).toBeVisible()
   })
 
   it('rendrer både AFP privat og pre-2025 offentlig AFP samtidig', () => {
@@ -718,7 +718,7 @@ describe('Gitt at AfpDetaljer rendres', () => {
 
       // Pre-2025 offentlig AFP
       expect(screen.getByText('AFP grad:')).toBeVisible()
-      expect(screen.getByText('100')).toBeVisible()
+      expect(screen.getByText('100 %')).toBeVisible()
 
       // Totalt skal det være 3 forskjellige seksjoner med AFP data
       const definitionLists = container.querySelectorAll('dl')
@@ -798,13 +798,13 @@ describe('Gitt at AfpDetaljer rendres', () => {
       )
 
       expect(screen.getByText('AFP grad:')).toBeVisible()
-      expect(screen.getByText('100')).toBeVisible()
+      expect(screen.getByText('100 %')).toBeVisible()
       expect(screen.getByText('Sluttpoengtall:')).toBeVisible()
       expect(screen.getByText('6.5')).toBeVisible()
       expect(screen.getByText('Poengår:')).toBeVisible()
-      expect(screen.getByText('35')).toBeVisible()
+      expect(screen.getByText('35 år')).toBeVisible()
       expect(screen.getByText('Trygdetid:')).toBeVisible()
-      expect(screen.getByText('40')).toBeVisible()
+      expect(screen.getByText('40 år')).toBeVisible()
     })
 
     it('rendrer ikke pre-2025 offentlig AFP når data er tom', () => {
@@ -847,7 +847,7 @@ describe('Gitt at AfpDetaljer rendres', () => {
       const mockDataWithUndefined: DetaljRad[] = [
         { tekst: 'AFP grad', verdi: undefined },
         { tekst: 'Sluttpoengtall' },
-        { tekst: 'Poengår', verdi: 35 },
+        { tekst: 'Poengår', verdi: '35 år' },
       ]
 
       renderWithProviders(
@@ -859,7 +859,7 @@ describe('Gitt at AfpDetaljer rendres', () => {
       expect(screen.getByText('AFP grad:')).toBeVisible()
       expect(screen.getByText('Sluttpoengtall:')).toBeVisible()
       expect(screen.getByText('Poengår:')).toBeVisible()
-      expect(screen.getByText('35')).toBeVisible()
+      expect(screen.getByText('35 år')).toBeVisible()
     })
 
     it('rendrer pre-2025 offentlig AFP sammen med AFP privat', () => {
@@ -929,7 +929,7 @@ describe('Gitt at AfpDetaljer rendres', () => {
 
       // Pre-2025 offentlig AFP
       expect(screen.getByText('AFP grad:')).toBeVisible()
-      expect(screen.getByText('100')).toBeVisible()
+      expect(screen.getByText('100 %')).toBeVisible()
 
       // Skal ha minst 3 definition lists (AFP privat x2, AFP offentlig, pre-2025)
       const definitionLists = container.querySelectorAll('dl')

--- a/src/components/Simulering/BeregningsdetaljerForOvergangskull/Felles/__tests__/AlderspensjonDetaljer.test.tsx
+++ b/src/components/Simulering/BeregningsdetaljerForOvergangskull/Felles/__tests__/AlderspensjonDetaljer.test.tsx
@@ -70,9 +70,9 @@ describe('Gitt at AlderspensjonDetaljer rendres', () => {
     ],
     opptjeningKap19: [
       { tekst: 'Andelsbrøk', verdi: '10/10' },
-      { tekst: 'Sluttpoengtall', verdi: 6.5 },
-      { tekst: 'Poengår', verdi: 35 },
-      { tekst: 'Trygdetid', verdi: 40 },
+      { tekst: 'Sluttpoengtall', verdi: '6.5' },
+      { tekst: 'Poengår', verdi: '35 år' },
+      { tekst: 'Trygdetid', verdi: '40 år' },
     ],
     opptjeningKap20: [
       { tekst: 'Andelsbrøk', verdi: '10/10' },

--- a/src/components/Simulering/BeregningsdetaljerForOvergangskull/__tests__/AfpDetaljerGrunnlag.test.tsx
+++ b/src/components/Simulering/BeregningsdetaljerForOvergangskull/__tests__/AfpDetaljerGrunnlag.test.tsx
@@ -35,8 +35,8 @@ describe('AfpDetaljerGrunnlag', () => {
   const defaultProps = {
     afpPrivatDetaljerListe: [
       [
-        { tekst: 'AFP grad', verdi: 100 },
-        { tekst: 'Kompensasjonsgrad', verdi: 0.76 },
+        { tekst: 'AFP grad', verdi: '100 %' },
+        { tekst: 'Kompensasjonsgrad', verdi: '76 %' },
       ],
     ],
     afpOffentligDetaljerListe: [
@@ -48,7 +48,7 @@ describe('AfpDetaljerGrunnlag', () => {
       { tekst: 'Sum alderspensjon', verdi: '28 000 kr' },
     ],
     opptjeningPre2025OffentligAfpListe: [
-      { tekst: 'AFP grad', verdi: 100 },
+      { tekst: 'AFP grad', verdi: '100 år' },
       { tekst: 'Sluttpoengtall', verdi: 6.5 },
     ],
   }

--- a/src/components/Simulering/BeregningsdetaljerForOvergangskull/__tests__/hooks.test.ts
+++ b/src/components/Simulering/BeregningsdetaljerForOvergangskull/__tests__/hooks.test.ts
@@ -258,8 +258,8 @@ describe('useBeregningsdetaljer', () => {
             tekst: 'Sluttpoengtall',
             verdi: formatDecimalWithComma(3),
           }),
-          expect.objectContaining({ tekst: 'Poengår', verdi: 9 }),
-          expect.objectContaining({ tekst: 'Trygdetid', verdi: 6 }),
+          expect.objectContaining({ tekst: 'Poengår', verdi: '9 år' }),
+          expect.objectContaining({ tekst: 'Trygdetid', verdi: '6 år' }),
         ])
       )
     })
@@ -352,8 +352,8 @@ describe('useBeregningsdetaljer', () => {
               tekst: 'Sluttpoengtall',
               verdi: formatDecimalWithComma(3),
             }),
-            expect.objectContaining({ tekst: 'Poengår', verdi: 9 }),
-            expect.objectContaining({ tekst: 'Trygdetid', verdi: 6 }),
+            expect.objectContaining({ tekst: 'Poengår', verdi: '9 år' }),
+            expect.objectContaining({ tekst: 'Trygdetid', verdi: '6 år' }),
           ])
         )
       })
@@ -374,7 +374,7 @@ describe('useBeregningsdetaljer', () => {
         result.current.alderspensjonDetaljerListe[0].opptjeningKap20
       ).toEqual([
         expect.objectContaining({ tekst: 'Andelsbrøk', verdi: '7/10' }),
-        expect.objectContaining({ tekst: 'Trygdetid', verdi: 7 }),
+        expect.objectContaining({ tekst: 'Trygdetid', verdi: '7 år' }),
         expect.objectContaining({
           tekst: 'Pensjonsbeholdning',
           verdi: `${formatInntekt(80000)} kr`,
@@ -467,7 +467,7 @@ describe('useBeregningsdetaljer', () => {
         // But other fields should still be present
         expect(opptjeningResult).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ tekst: 'Trygdetid', verdi: 7 }),
+            expect.objectContaining({ tekst: 'Trygdetid', verdi: '7 år' }),
             expect.objectContaining({
               tekst: 'Pensjonsbeholdning',
               verdi: `${formatInntekt(80000)} kr`,
@@ -490,13 +490,13 @@ describe('useBeregningsdetaljer', () => {
       )
       expect(result.current.opptjeningPre2025OffentligAfpListe).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ tekst: 'AFP grad', verdi: 50 }),
+          expect.objectContaining({ tekst: 'AFP grad', verdi: '50 %' }),
           expect.objectContaining({
             tekst: 'Sluttpoengtall',
             verdi: formatDecimalWithComma(2),
           }),
-          expect.objectContaining({ tekst: 'Poengår', verdi: 7 }),
-          expect.objectContaining({ tekst: 'Trygdetid', verdi: 5 }),
+          expect.objectContaining({ tekst: 'Poengår', verdi: '7 år' }),
+          expect.objectContaining({ tekst: 'Trygdetid', verdi: '5 år' }),
         ])
       )
     })
@@ -541,8 +541,8 @@ describe('useBeregningsdetaljer', () => {
         )
         expect(result.current.opptjeningPre2025OffentligAfpListe).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ tekst: 'Poengår', verdi: 7 }),
-            expect.objectContaining({ tekst: 'Trygdetid', verdi: 5 }),
+            expect.objectContaining({ tekst: 'Poengår', verdi: '7 år' }),
+            expect.objectContaining({ tekst: 'Trygdetid', verdi: '5 år' }),
           ])
         )
       })

--- a/src/components/Simulering/BeregningsdetaljerForOvergangskull/hooks.ts
+++ b/src/components/Simulering/BeregningsdetaljerForOvergangskull/hooks.ts
@@ -138,6 +138,9 @@ function getAlderspensjonDetaljerListe(
     if (ap.andelsbroekKap19 === 0) {
       return []
     }
+
+    const sumPoengaar = (ap.poengaarFoer92 ?? 0) + (ap.poengaarEtter91 ?? 0)
+
     return [
       {
         tekst: 'Andelsbrøk',
@@ -149,9 +152,12 @@ function getAlderspensjonDetaljerListe(
       },
       {
         tekst: 'Poengår',
-        verdi: (ap.poengaarFoer92 ?? 0) + (ap.poengaarEtter91 ?? 0),
+        verdi: sumPoengaar ? `${sumPoengaar} år` : 0,
       },
-      { tekst: 'Trygdetid', verdi: ap.trygdetidKap19 },
+      {
+        tekst: 'Trygdetid',
+        verdi: ap.trygdetidKap19 ? `${ap.trygdetidKap19} år` : 0,
+      },
     ].filter(
       (rad) =>
         rad.verdi !== undefined &&
@@ -171,7 +177,10 @@ function getAlderspensjonDetaljerListe(
         tekst: 'Andelsbrøk',
         verdi: ap.andelsbroekKap20 ? `${ap.andelsbroekKap20 * 10}/10` : 0,
       },
-      { tekst: 'Trygdetid', verdi: ap.trygdetidKap20 },
+      {
+        tekst: 'Trygdetid',
+        verdi: ap.trygdetidKap20 ? `${ap.trygdetidKap20} år` : 0,
+      },
       {
         tekst: 'Pensjonsbeholdning',
         verdi: `${formatInntekt(ap.pensjonBeholdningFoerUttakBeloep)} kr`,
@@ -343,28 +352,40 @@ export function useBeregningsdetaljer(
       ]
     })()
 
-    const opptjeningPre2025OffentligAfpListe: DetaljRad[] = pre2025OffentligAfp
-      ? [
-          { tekst: 'AFP grad', verdi: pre2025OffentligAfp.afpGrad },
-          {
-            tekst: 'Sluttpoengtall',
-            verdi: formatDecimalWithComma(pre2025OffentligAfp.sluttpoengtall),
-          },
-          {
-            tekst: 'Poengår',
-            verdi:
-              (pre2025OffentligAfp.poengaarTom1991 ?? 0) +
-              (pre2025OffentligAfp.poengaarFom1992 ?? 0),
-          },
-          { tekst: 'Trygdetid', verdi: pre2025OffentligAfp.trygdetid },
-        ].filter(
-          (rad) =>
-            rad.verdi !== undefined &&
-            (rad.tekst === 'Poengår' ||
-              rad.tekst === 'Trygdetid' ||
-              rad.verdi !== 0)
-        )
-      : []
+    const opptjeningPre2025OffentligAfpListe: DetaljRad[] = (() => {
+      if (!pre2025OffentligAfp) {
+        return []
+      }
+      const sumPoengaarPre2025OffentligAfp =
+        (pre2025OffentligAfp.poengaarTom1991 ?? 0) +
+        (pre2025OffentligAfp.poengaarFom1992 ?? 0)
+
+      return [
+        { tekst: 'AFP grad', verdi: `${pre2025OffentligAfp.afpGrad} %` },
+        {
+          tekst: 'Sluttpoengtall',
+          verdi: formatDecimalWithComma(pre2025OffentligAfp.sluttpoengtall),
+        },
+        {
+          tekst: 'Poengår',
+          verdi: sumPoengaarPre2025OffentligAfp
+            ? `${sumPoengaarPre2025OffentligAfp} år`
+            : 0,
+        },
+        {
+          tekst: 'Trygdetid',
+          verdi: pre2025OffentligAfp.trygdetid
+            ? `${pre2025OffentligAfp.trygdetid} år`
+            : 0,
+        },
+      ].filter(
+        (rad) =>
+          rad.verdi !== undefined &&
+          (rad.tekst === 'Poengår' ||
+            rad.tekst === 'Trygdetid' ||
+            rad.verdi !== 0)
+      )
+    })()
 
     return {
       alderspensjonDetaljerListe,


### PR DESCRIPTION
[PEK-1393](https://jira.adeo.no/projects/PEK/issues/PEK-1393)

Beregningsdetaljer mangler benevning på noen av sifrene i tabellene i detaljer; Poengår og Trygdetid bør ha 'år' etter seg og AFP grad bør ha '%'. 

### Before

<img width="733" height="853" alt="Screenshot 2025-07-24 at 12 53 34" src="https://github.com/user-attachments/assets/68f7e051-b8f1-46a3-8592-21dedcc6332e" />

### After


<img width="745" height="854" alt="Screenshot 2025-07-24 at 12 48 32" src="https://github.com/user-attachments/assets/814f68f2-4a99-4724-bbe7-f34ac87b8e1b" />


