### PR TITLE
PEK-1219 backup sanity i gcp

### DIFF
--- a/.github/workflows/backup-sanity-dataset.yaml
+++ b/.github/workflows/backup-sanity-dataset.yaml
@@ -1,0 +1,42 @@
+name: Backup Routine
+on:
+  workflow_dispatch:
+  schedule:
+    # Kjøres kl. 06:00 hver dag
+    - cron: "0 6 * * *"
+jobs:
+  backup-sanity:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    name: Backup Sanity dataset
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set backup file name
+        run: |
+            echo "FILE_NAME=backup-$(date +%F).tar.gz" >> $GITHUB_ENV
+
+      - name: Create backups directory
+        run: mkdir -p backups
+
+      - name: Export dataset
+        uses: sanity-io/github-action-sanity@v0.7-alpha
+        env:
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+        with:
+          args: dataset export production backups/${{ env.FILE_NAME }}
+
+      - name: Authenticate to Google Cloud (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: ./backups/${{ env.FILE_NAME }}
+          destination: pkf/sanity-backups/
+          if-no-files-found: error


### PR DESCRIPTION
Bruker Sanity "Viewer"-token opprettet i Sanity og Sanity GitHub Action.
Bruker Direct Workload Identity Federation (WIF) for GCP autentisering som er det tryggeste måten å autentisere GitHub mot GCP. Bruk av JSON-key koblet til service account er ikke anbefalt.

Aksel og Etterlatte gjorde noe lignende, men begge brukte javascript for å laste ned backups og JSON-key for autentisere mot GCP:
[https://github.com/navikt/aksel/blob/main/.github/workflows/backup-sanity.yml](https://github.com/navikt/aksel/blob/main/.github/workflows/backup-sanity.yml)
[https://github.com/navikt/pensjon-etterlatte/blob/main/.github/workflows/backup-brukerdialog-sanity-innhold.yaml](https://github.com/navikt/pensjon-etterlatte/blob/main/.github/workflows/backup-brukerdialog-sanity-innhold.yaml)