### PR TITLE
PEK-1373 Lister på smale skjermer

### DIFF
--- a/src/components/Simulering/BeregningsdetaljerForOvergangskull/Felles/AlderspensjonDetaljer.tsx
+++ b/src/components/Simulering/BeregningsdetaljerForOvergangskull/Felles/AlderspensjonDetaljer.tsx
@@ -89,7 +89,11 @@ function renderDetaljer(
             const isBold = index === row.length - 1 && key === 'alderspensjon'
             return (
               <React.Fragment key={index}>
-                <HStack justify="space-between" className={styles.hstackRow}>
+                <HStack
+                  wrap={false}
+                  justify="space-between"
+                  className={styles.hstackRow}
+                >
                   <dt style={{ marginRight: '1rem' }}>
                     {isBold ? (
                       <strong>{detalj.tekst}:</strong>

--- a/src/components/Simulering/BeregningsdetaljerForOvergangskull/__tests__/hooks.test.ts
+++ b/src/components/Simulering/BeregningsdetaljerForOvergangskull/__tests__/hooks.test.ts
@@ -96,36 +96,36 @@ describe('useBeregningsdetaljer', () => {
       expect(alderspensjonData.alderspensjon).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            tekst: 'Grunnpensjon (kap. 19)',
-            verdi: `${formatInntekt(83)} kr`,
+            tekst: 'Grunnpensjon (kap. 19)',
+            verdi: `${formatInntekt(83)} kr`,
           }),
           expect.objectContaining({
-            tekst: 'Tilleggspensjon (kap. 19)',
-            verdi: `${formatInntekt(167)} kr`,
+            tekst: 'Tilleggspensjon (kap. 19)',
+            verdi: `${formatInntekt(167)} kr`,
           }),
           expect.objectContaining({
-            tekst: 'Skjermingstillegg (kap. 19)',
-            verdi: `${formatInntekt(25)} kr`,
+            tekst: 'Skjermingstillegg (kap. 19)',
+            verdi: `${formatInntekt(25)} kr`,
           }),
           expect.objectContaining({
-            tekst: 'Pensjonstillegg (kap. 19)',
-            verdi: `${formatInntekt(33)} kr`,
+            tekst: 'Pensjonstillegg (kap. 19)',
+            verdi: `${formatInntekt(33)} kr`,
           }),
           expect.objectContaining({
-            tekst: 'Gjenlevendetillegg (kap. 19)',
-            verdi: '29 kr',
+            tekst: 'Gjenlevendetillegg (kap. 19)',
+            verdi: '29 kr',
           }),
           expect.objectContaining({
-            tekst: 'Inntektspensjon (kap. 20)',
-            verdi: `${formatInntekt(42)} kr`,
+            tekst: 'Inntektspensjon (kap. 20)',
+            verdi: `${formatInntekt(42)} kr`,
           }),
           expect.objectContaining({
-            tekst: 'Garantipensjon (kap. 20)',
-            verdi: `${formatInntekt(50)} kr`,
+            tekst: 'Garantipensjon (kap. 20)',
+            verdi: `${formatInntekt(50)} kr`,
           }),
           expect.objectContaining({
             tekst: 'Sum alderspensjon',
-            verdi: `${formatInntekt(429)} kr`,
+            verdi: `${formatInntekt(429)} kr`,
           }),
         ])
       )
@@ -182,8 +182,8 @@ describe('useBeregningsdetaljer', () => {
         ).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              tekst: 'Gjenlevendetillegg (kap. 19)',
-              verdi: '50 kr',
+              tekst: 'Gjenlevendetillegg (kap. 19)',
+              verdi: '50 kr',
             }),
           ])
         )
@@ -258,8 +258,8 @@ describe('useBeregningsdetaljer', () => {
             tekst: 'Sluttpoengtall',
             verdi: formatDecimalWithComma(3),
           }),
-          expect.objectContaining({ tekst: 'Poengår', verdi: '9 år' }),
-          expect.objectContaining({ tekst: 'Trygdetid', verdi: '6 år' }),
+          expect.objectContaining({ tekst: 'Poengår', verdi: '9 år' }),
+          expect.objectContaining({ tekst: 'Trygdetid', verdi: '6 år' }),
         ])
       )
     })
@@ -283,7 +283,7 @@ describe('useBeregningsdetaljer', () => {
           result.current.alderspensjonDetaljerListe[0].opptjeningKap19
         ).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ tekst: 'Poengår', verdi: '0 år' }),
+            expect.objectContaining({ tekst: 'Poengår', verdi: '0 år' }),
           ])
         )
       })
@@ -302,7 +302,7 @@ describe('useBeregningsdetaljer', () => {
           result.current.alderspensjonDetaljerListe[0].opptjeningKap19
         ).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ tekst: 'Trygdetid', verdi: '0 år' }),
+            expect.objectContaining({ tekst: 'Trygdetid', verdi: '0 år' }),
           ])
         )
       })
@@ -352,8 +352,8 @@ describe('useBeregningsdetaljer', () => {
               tekst: 'Sluttpoengtall',
               verdi: formatDecimalWithComma(3),
             }),
-            expect.objectContaining({ tekst: 'Poengår', verdi: '9 år' }),
-            expect.objectContaining({ tekst: 'Trygdetid', verdi: '6 år' }),
+            expect.objectContaining({ tekst: 'Poengår', verdi: '9 år' }),
+            expect.objectContaining({ tekst: 'Trygdetid', verdi: '6 år' }),
           ])
         )
       })
@@ -374,10 +374,10 @@ describe('useBeregningsdetaljer', () => {
         result.current.alderspensjonDetaljerListe[0].opptjeningKap20
       ).toEqual([
         expect.objectContaining({ tekst: 'Andelsbrøk', verdi: '7/10' }),
-        expect.objectContaining({ tekst: 'Trygdetid', verdi: '7 år' }),
+        expect.objectContaining({ tekst: 'Trygdetid', verdi: '7 år' }),
         expect.objectContaining({
           tekst: 'Pensjonsbeholdning',
-          verdi: `${formatInntekt(80000)} kr`,
+          verdi: `${formatInntekt(80000)} kr`,
         }),
       ])
     })
@@ -397,7 +397,7 @@ describe('useBeregningsdetaljer', () => {
           result.current.alderspensjonDetaljerListe[0].opptjeningKap20
         ).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ tekst: 'Trygdetid', verdi: '0 år' }),
+            expect.objectContaining({ tekst: 'Trygdetid', verdi: '0 år' }),
           ])
         )
       })
@@ -421,7 +421,7 @@ describe('useBeregningsdetaljer', () => {
           expect.arrayContaining([
             expect.objectContaining({
               tekst: 'Pensjonsbeholdning',
-              verdi: `${formatInntekt(0)} kr`,
+              verdi: `${formatInntekt(0)} kr`,
             }),
           ])
         )
@@ -467,10 +467,10 @@ describe('useBeregningsdetaljer', () => {
         // But other fields should still be present
         expect(opptjeningResult).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ tekst: 'Trygdetid', verdi: '7 år' }),
+            expect.objectContaining({ tekst: 'Trygdetid', verdi: '7 år' }),
             expect.objectContaining({
               tekst: 'Pensjonsbeholdning',
-              verdi: `${formatInntekt(80000)} kr`,
+              verdi: `${formatInntekt(80000)} kr`,
             }),
           ])
         )
@@ -490,13 +490,13 @@ describe('useBeregningsdetaljer', () => {
       )
       expect(result.current.opptjeningPre2025OffentligAfpListe).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ tekst: 'AFP grad', verdi: '50 %' }),
+          expect.objectContaining({ tekst: 'AFP grad', verdi: '50 %' }),
           expect.objectContaining({
             tekst: 'Sluttpoengtall',
             verdi: formatDecimalWithComma(2),
           }),
-          expect.objectContaining({ tekst: 'Poengår', verdi: '7 år' }),
-          expect.objectContaining({ tekst: 'Trygdetid', verdi: '5 år' }),
+          expect.objectContaining({ tekst: 'Poengår', verdi: '7 år' }),
+          expect.objectContaining({ tekst: 'Trygdetid', verdi: '5 år' }),
         ])
       )
     })
@@ -513,7 +513,7 @@ describe('useBeregningsdetaljer', () => {
         )
         expect(result.current.opptjeningPre2025OffentligAfpListe).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ tekst: 'Poengår', verdi: '0 år' }),
+            expect.objectContaining({ tekst: 'Poengår', verdi: '0 år' }),
           ])
         )
       })
@@ -541,8 +541,8 @@ describe('useBeregningsdetaljer', () => {
         )
         expect(result.current.opptjeningPre2025OffentligAfpListe).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ tekst: 'Poengår', verdi: '7 år' }),
-            expect.objectContaining({ tekst: 'Trygdetid', verdi: '5 år' }),
+            expect.objectContaining({ tekst: 'Poengår', verdi: '7 år' }),
+            expect.objectContaining({ tekst: 'Trygdetid', verdi: '5 år' }),
           ])
         )
       })
@@ -570,19 +570,19 @@ describe('useBeregningsdetaljer', () => {
         expect.arrayContaining([
           expect.objectContaining({
             tekst: 'Kompensasjonstillegg',
-            verdi: `${formatInntekt(500)} kr`,
+            verdi: `${formatInntekt(500)} kr`,
           }),
           expect.objectContaining({
             tekst: 'Kronetillegg',
-            verdi: `${formatInntekt(1000)} kr`,
+            verdi: `${formatInntekt(1000)} kr`,
           }),
           expect.objectContaining({
             tekst: 'Livsvarig del',
-            verdi: `${formatInntekt(12000)} kr`,
+            verdi: `${formatInntekt(12000)} kr`,
           }),
           expect.objectContaining({
             tekst: 'Sum AFP',
-            verdi: `${formatInntekt(15000)} kr`,
+            verdi: `${formatInntekt(15000)} kr`,
           }),
         ])
       )
@@ -622,11 +622,11 @@ describe('useBeregningsdetaljer', () => {
         expect.arrayContaining([
           expect.objectContaining({
             tekst: 'Kompensasjonstillegg',
-            verdi: `${formatInntekt(500)} kr`,
+            verdi: `${formatInntekt(500)} kr`,
           }),
           expect.objectContaining({
             tekst: 'Sum AFP',
-            verdi: `${formatInntekt(15000)} kr`,
+            verdi: `${formatInntekt(15000)} kr`,
           }),
         ])
       )
@@ -636,11 +636,11 @@ describe('useBeregningsdetaljer', () => {
         expect.arrayContaining([
           expect.objectContaining({
             tekst: 'Kompensasjonstillegg',
-            verdi: `${formatInntekt(600)} kr`,
+            verdi: `${formatInntekt(600)} kr`,
           }),
           expect.objectContaining({
             tekst: 'Sum AFP',
-            verdi: `${formatInntekt(20000)} kr`,
+            verdi: `${formatInntekt(20000)} kr`,
           }),
         ])
       )
@@ -686,11 +686,11 @@ describe('useBeregningsdetaljer', () => {
         expect.arrayContaining([
           expect.objectContaining({
             tekst: 'Livsvarig del',
-            verdi: `${formatInntekt(12000)} kr`,
+            verdi: `${formatInntekt(12000)} kr`,
           }),
           expect.objectContaining({
             tekst: 'Sum AFP',
-            verdi: `${formatInntekt(15000)} kr`,
+            verdi: `${formatInntekt(15000)} kr`,
           }),
         ])
       )
@@ -723,7 +723,7 @@ describe('useBeregningsdetaljer', () => {
         expect.arrayContaining([
           expect.objectContaining({
             tekst: 'Månedlig livsvarig avtalefestet pensjon (AFP)',
-            verdi: `${formatInntekt(12000)} kr`,
+            verdi: `${formatInntekt(12000)} kr`,
           }),
         ])
       )
@@ -751,7 +751,7 @@ describe('useBeregningsdetaljer', () => {
         expect.arrayContaining([
           expect.objectContaining({
             tekst: 'Månedlig livsvarig avtalefestet pensjon (AFP)',
-            verdi: `${formatInntekt(12000)} kr`,
+            verdi: `${formatInntekt(12000)} kr`,
           }),
         ])
       )
@@ -813,20 +813,20 @@ describe('useBeregningsdetaljer', () => {
       expect(result.current.pre2025OffentligAfpDetaljerListe).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            tekst: 'Grunnpensjon (kap. 19)',
-            verdi: `${formatInntekt(1000)} kr`,
+            tekst: 'Grunnpensjon (kap. 19)',
+            verdi: `${formatInntekt(1000)} kr`,
           }),
           expect.objectContaining({
-            tekst: 'Tilleggspensjon (kap. 19)',
-            verdi: `${formatInntekt(2000)} kr`,
+            tekst: 'Tilleggspensjon (kap. 19)',
+            verdi: `${formatInntekt(2000)} kr`,
           }),
           expect.objectContaining({
             tekst: 'AFP-tillegg',
-            verdi: `${formatInntekt(500)} kr`,
+            verdi: `${formatInntekt(500)} kr`,
           }),
           expect.objectContaining({
             tekst: 'Sum AFP',
-            verdi: `${formatInntekt(3500)} kr`,
+            verdi: `${formatInntekt(3500)} kr`,
           }),
         ])
       )
@@ -853,16 +853,16 @@ describe('useBeregningsdetaljer', () => {
       expect(result.current.pre2025OffentligAfpDetaljerListe).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            tekst: 'Grunnpensjon (kap. 19)',
-            verdi: `${formatInntekt(1000)} kr`,
+            tekst: 'Grunnpensjon (kap. 19)',
+            verdi: `${formatInntekt(1000)} kr`,
           }),
           expect.objectContaining({
             tekst: 'AFP-tillegg',
-            verdi: `${formatInntekt(500)} kr`,
+            verdi: `${formatInntekt(500)} kr`,
           }),
           expect.objectContaining({
             tekst: 'Sum AFP',
-            verdi: `${formatInntekt(1500)} kr`,
+            verdi: `${formatInntekt(1500)} kr`,
           }),
         ])
       )
@@ -921,7 +921,7 @@ describe('useBeregningsdetaljer', () => {
         (rad) => rad.tekst === 'Sum AFP'
       )
       expect(sumRad).toBeDefined()
-      expect(sumRad?.verdi).toBe(`${formatInntekt(3500)} kr`)
+      expect(sumRad?.verdi).toBe(`${formatInntekt(3500)} kr`)
     })
   })
 })

--- a/src/components/Simulering/BeregningsdetaljerForOvergangskull/hooks.ts
+++ b/src/components/Simulering/BeregningsdetaljerForOvergangskull/hooks.ts
@@ -146,7 +146,7 @@ function getAlderspensjonDetaljerListe(
             inntektspensjonBeloep +
             garantipensjonBeloep +
             gjenlevendetillegg
-        )} kr`,
+        )} kr`,
       },
     ].filter((rad) => rad.verdi !== '0 kr')
   }
@@ -392,7 +392,7 @@ export function useBeregningsdetaljer(
         {
           tekst: 'AFP grad',
           verdi: pre2025OffentligAfp.afpGrad
-            ? `${pre2025OffentligAfp.afpGrad} %`
+            ? `${pre2025OffentligAfp.afpGrad} %`
             : 0,
         },
         {

--- a/src/components/Simulering/BeregningsdetaljerForOvergangskull/hooks.ts
+++ b/src/components/Simulering/BeregningsdetaljerForOvergangskull/hooks.ts
@@ -96,45 +96,45 @@ function getAlderspensjonDetaljerListe(
     return [
       {
         tekst: shouldShowParentheses
-          ? 'Grunnpensjon (kap. 19)'
+          ? 'Grunnpensjon (kap. 19)'
           : 'Grunnpensjon',
-        verdi: `${formatInntekt(grunnpensjon)} kr`,
+        verdi: `${formatInntekt(grunnpensjon)} kr`,
       },
       {
         tekst: shouldShowParentheses
-          ? 'Tilleggspensjon (kap. 19)'
+          ? 'Tilleggspensjon (kap. 19)'
           : 'Tilleggspensjon',
-        verdi: `${formatInntekt(tilleggspensjon)} kr`,
+        verdi: `${formatInntekt(tilleggspensjon)} kr`,
       },
       {
         tekst: shouldShowParentheses
-          ? 'Skjermingstillegg (kap. 19)'
+          ? 'Skjermingstillegg (kap. 19)'
           : 'Skjermingstillegg',
-        verdi: `${formatInntekt(skjermingstillegg)} kr`,
+        verdi: `${formatInntekt(skjermingstillegg)} kr`,
       },
       {
         tekst: shouldShowParentheses
-          ? 'Pensjonstillegg (kap. 19)'
+          ? 'Pensjonstillegg (kap. 19)'
           : 'Pensjonstillegg',
-        verdi: `${formatInntekt(pensjonstillegg)} kr`,
+        verdi: `${formatInntekt(pensjonstillegg)} kr`,
       },
       {
         tekst: shouldShowParentheses
-          ? 'Gjenlevendetillegg (kap. 19)'
+          ? 'Gjenlevendetillegg (kap. 19)'
           : 'Gjenlevendetillegg',
-        verdi: `${formatInntekt(gjenlevendetillegg)} kr`,
+        verdi: `${formatInntekt(gjenlevendetillegg)} kr`,
       },
       {
         tekst: shouldShowParentheses
-          ? 'Inntektspensjon (kap. 20)'
+          ? 'Inntektspensjon (kap. 20)'
           : 'Inntektspensjon',
-        verdi: `${formatInntekt(inntektspensjonBeloep)} kr`,
+        verdi: `${formatInntekt(inntektspensjonBeloep)} kr`,
       },
       {
         tekst: shouldShowParentheses
-          ? 'Garantipensjon (kap. 20)'
+          ? 'Garantipensjon (kap. 20)'
           : 'Garantipensjon',
-        verdi: `${formatInntekt(garantipensjonBeloep)} kr`,
+        verdi: `${formatInntekt(garantipensjonBeloep)} kr`,
       },
       {
         tekst: 'Sum alderspensjon',
@@ -148,7 +148,7 @@ function getAlderspensjonDetaljerListe(
             gjenlevendetillegg
         )} kr`,
       },
-    ].filter((rad) => rad.verdi !== '0 kr')
+    ].filter((rad) => rad.verdi !== '0 kr')
   }
 
   const getOpptjeningKap19Details = (ap: AlderspensjonPensjonsberegning) => {
@@ -171,11 +171,11 @@ function getAlderspensjonDetaljerListe(
       },
       {
         tekst: 'Poengår',
-        verdi: `${sumPoengaar} år`,
+        verdi: `${sumPoengaar} år`,
       },
       {
         tekst: 'Trygdetid',
-        verdi: ap.trygdetidKap19 ? `${ap.trygdetidKap19} år` : '0 år',
+        verdi: ap.trygdetidKap19 ? `${ap.trygdetidKap19} år` : '0 år',
       },
     ].filter(
       (rad) =>
@@ -197,11 +197,11 @@ function getAlderspensjonDetaljerListe(
       },
       {
         tekst: 'Trygdetid',
-        verdi: ap.trygdetidKap20 ? `${ap.trygdetidKap20} år` : '0 år',
+        verdi: ap.trygdetidKap20 ? `${ap.trygdetidKap20} år` : '0 år',
       },
       {
         tekst: 'Pensjonsbeholdning',
-        verdi: `${formatInntekt(ap.pensjonBeholdningFoerUttakBeloep ?? 0)} kr`,
+        verdi: `${formatInntekt(ap.pensjonBeholdningFoerUttakBeloep ?? 0)} kr`,
       },
     ].filter(
       (rad) =>
@@ -272,28 +272,28 @@ export function useBeregningsdetaljer(
 
           return [
             {
-              tekst: 'Grunnpensjon (kap. 19)',
-              verdi: `${formatInntekt(grunnpensjon)} kr`,
+              tekst: 'Grunnpensjon (kap. 19)',
+              verdi: `${formatInntekt(grunnpensjon)} kr`,
             },
             {
-              tekst: 'Tilleggspensjon (kap. 19)',
-              verdi: `${formatInntekt(tilleggspensjon)} kr`,
+              tekst: 'Tilleggspensjon (kap. 19)',
+              verdi: `${formatInntekt(tilleggspensjon)} kr`,
             },
             {
               tekst: 'AFP-tillegg',
-              verdi: `${formatInntekt(afpTillegg)} kr`,
+              verdi: `${formatInntekt(afpTillegg)} kr`,
             },
             {
               tekst: 'Særtillegg',
-              verdi: `${formatInntekt(saertillegg)} kr`,
+              verdi: `${formatInntekt(saertillegg)} kr`,
             },
             {
               tekst: 'Sum AFP',
               verdi: `${formatInntekt(
                 grunnpensjon + tilleggspensjon + afpTillegg + saertillegg
-              )} kr`,
+              )} kr`,
             },
-          ].filter((rad) => rad.verdi !== '0 kr')
+          ].filter((rad) => rad.verdi !== '0 kr')
         })()
       : []
 
@@ -333,23 +333,23 @@ export function useBeregningsdetaljer(
           {
             tekst: 'Kompensasjonstillegg',
             verdi: afp.kompensasjonstillegg
-              ? `${formatInntekt(afp.kompensasjonstillegg)} kr`
+              ? `${formatInntekt(afp.kompensasjonstillegg)} kr`
               : 0,
           },
           {
             tekst: 'Kronetillegg',
             verdi: afp.kronetillegg
-              ? `${formatInntekt(afp.kronetillegg)} kr`
+              ? `${formatInntekt(afp.kronetillegg)} kr`
               : 0,
           },
           {
             tekst: 'Livsvarig del',
-            verdi: afp.livsvarig ? `${formatInntekt(afp.livsvarig)} kr` : 0,
+            verdi: afp.livsvarig ? `${formatInntekt(afp.livsvarig)} kr` : 0,
           },
           {
             tekst: 'Sum AFP',
             verdi: afp.maanedligBeloep
-              ? `${formatInntekt(afp.maanedligBeloep)} kr`
+              ? `${formatInntekt(afp.maanedligBeloep)} kr`
               : 0,
           },
         ].filter((rad) => rad.verdi !== 0)
@@ -375,7 +375,7 @@ export function useBeregningsdetaljer(
       return [
         {
           tekst: 'Månedlig livsvarig avtalefestet pensjon (AFP)',
-          verdi: `${formatInntekt(afpOffentligVedUttak?.maanedligBeloep ?? 0)} kr`,
+          verdi: `${formatInntekt(afpOffentligVedUttak?.maanedligBeloep ?? 0)} kr`,
         },
       ]
     })()
@@ -403,12 +403,12 @@ export function useBeregningsdetaljer(
         },
         {
           tekst: 'Poengår',
-          verdi: `${sumPoengaarPre2025OffentligAfp} år`,
+          verdi: `${sumPoengaarPre2025OffentligAfp} år`,
         },
         {
           tekst: 'Trygdetid',
           verdi: pre2025OffentligAfp.trygdetid
-            ? `${pre2025OffentligAfp.trygdetid} år`
+            ? `${pre2025OffentligAfp.trygdetid} år`
             : 0,
         },
       ].filter(


### PR DESCRIPTION
Lagt til no break spaces og unngått wrapping på HStack i detaljer. Dette gjør at verdien alltid er høyrestilt og ikke wrappes under teksten.