### PR TITLE
Pek 1385 fix readmore scroll hopp

### DIFF
--- a/src/components/common/ShowMore/ShowMore.styles.css
+++ b/src/components/common/ShowMore/ShowMore.styles.css
@@ -40,13 +40,11 @@
 }
 
 .navds-show-more__content {
-  transition: height cubic-bezier(0, 0.3, 0.15, 1) 400ms;
   overflow: hidden;
   height: max-content;
 }
 
 .navds-show-more--closed .navds-show-more__content {
-  transition-duration: 0s;
   mask-image: var(--ac-show-more-mask);
   overflow: hidden;
 }


### PR DESCRIPTION
Fixes: [PEK-1385](https://jira.adeo.no/projects/PEK/issues/PEK-1385)

Skjer når det er langt innhold i `ShowMore` component.

**Before:**


https://github.com/user-attachments/assets/4ab69d9b-8eee-4735-806d-0f2d28c77e45

 **After:** 

https://github.com/user-attachments/assets/d0b302be-1ea3-4678-99a2-f826325e8fc6

