### PR TITLE
Pek 1444 oppdater landing side

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,11 +18,6 @@
       crossorigin
     />
     <title>Pensjonskalkulator - Pensjon</title>
-    <style>
-      #root {
-        min-height: 55vh;
-      }
-    </style>
   </head>
   <body>
     <div id="decorator-header"></div>

--- a/src/components/common/PageFramework/FrameComponent.module.scss
+++ b/src/components/common/PageFramework/FrameComponent.module.scss
@@ -7,6 +7,10 @@
   &__white {
     background: var(--a-white);
   }
+
+  &__noMinHeight {
+    min-height: 0;
+  }
 }
 
 .content {

--- a/src/components/common/PageFramework/FrameComponent.module.scss.d.ts
+++ b/src/components/common/PageFramework/FrameComponent.module.scss.d.ts
@@ -1,6 +1,7 @@
 declare const classNames: {
   readonly main: "main";
   readonly main__white: "main__white";
+  readonly main__noMinHeight: "main__noMinHeight";
   readonly content: "content";
   readonly content__isFramed: "content__isFramed";
   readonly headerGroup: "headerGroup";

--- a/src/components/common/PageFramework/FrameComponent.tsx
+++ b/src/components/common/PageFramework/FrameComponent.tsx
@@ -15,11 +15,13 @@ export const FrameComponent: React.FC<{
   hasWhiteBg?: boolean
   shouldShowLogo?: boolean
   children?: React.JSX.Element
+  noMinHeight?: boolean
 }> = ({
   isFullWidth,
   hasWhiteBg = false,
   shouldShowLogo = false,
   children,
+  noMinHeight = false,
 }) => {
   const intl = useIntl()
 
@@ -27,6 +29,7 @@ export const FrameComponent: React.FC<{
     <div
       className={clsx(styles.main, {
         [styles.main__white]: hasWhiteBg,
+        [styles.main__noMinHeight]: noMinHeight,
       })}
     >
       <div

--- a/src/components/common/PageFramework/PageFramework.tsx
+++ b/src/components/common/PageFramework/PageFramework.tsx
@@ -28,6 +28,7 @@ export const PageFramework: React.FC<{
   shouldShowLogo?: boolean
   shouldRedirectNonAuthenticated?: boolean
   showLoader?: boolean
+  noMinHeight?: boolean
   children?: React.JSX.Element
 }> = ({
   shouldRedirectNonAuthenticated = true,

--- a/src/components/stegvisning/Start/Start.module.scss
+++ b/src/components/stegvisning/Start/Start.module.scss
@@ -61,3 +61,11 @@
   display: block;
   margin-top: 0;
 }
+
+.alert {
+  margin-top: var(--a-spacing-8);
+  padding: var(--a-spacing-4) var(--a-spacing-5);
+  background-color: var(--a-surface-info-subtle);
+  border: 1px solid var(--a-data-surface-4-subtle);
+  border-radius: var(--a-spacing-3);
+}

--- a/src/components/stegvisning/Start/Start.module.scss.d.ts
+++ b/src/components/stegvisning/Start/Start.module.scss.d.ts
@@ -10,5 +10,6 @@ declare const classNames: {
   readonly ellipse__green: "ellipse__green";
   readonly button: "button";
   readonly link: "link";
+  readonly alert: "alert";
 };
 export = classNames;

--- a/src/components/stegvisning/Start/StartForBrukereUnder75.tsx
+++ b/src/components/stegvisning/Start/StartForBrukereUnder75.tsx
@@ -97,7 +97,7 @@ export function StartForBrukereUnder75({
             height="1.25rem"
           />
         </Link>
-        <div className={styles.alert}>
+        <div className={styles.alert} data-testid="stegvisning-start-alert">
           <Heading size="xsmall" level="4">
             <FormattedMessage id="stegvisning.start.alert.title" />
           </Heading>

--- a/src/components/stegvisning/Start/StartForBrukereUnder75.tsx
+++ b/src/components/stegvisning/Start/StartForBrukereUnder75.tsx
@@ -1,7 +1,7 @@
 import { FormattedMessage, useIntl } from 'react-intl'
 
 import { ExternalLinkIcon } from '@navikt/aksel-icons'
-import { Button, Heading, Link } from '@navikt/ds-react'
+import { BodyLong, Button, Heading, Link } from '@navikt/ds-react'
 
 import { InfoOmFremtidigVedtak } from '@/components/InfoOmFremtidigVedtak'
 import { Card } from '@/components/common/Card'
@@ -97,6 +97,15 @@ export function StartForBrukereUnder75({
             height="1.25rem"
           />
         </Link>
+        <div className={styles.alert}>
+          <Heading size="xsmall" level="4">
+            <FormattedMessage id="stegvisning.start.alert.title" />
+          </Heading>
+
+          <BodyLong size="medium">
+            <FormattedMessage id="stegvisning.start.alert.description" />
+          </BodyLong>
+        </div>
       </Card>
     </>
   )

--- a/src/components/stegvisning/Start/__tests__/StartForBrukereUnder75.test.tsx
+++ b/src/components/stegvisning/Start/__tests__/StartForBrukereUnder75.test.tsx
@@ -72,6 +72,7 @@ describe('stegvisning - Start', () => {
         { exact: false }
       )
     ).toBeVisible()
+    expect(screen.getByTestId('stegvisning-start-alert')).toBeVisible()
   })
 
   it('rendrer slik den skal med vedtak om alderspensjon og uføregrad', async () => {
@@ -100,6 +101,7 @@ describe('stegvisning - Start', () => {
       screen.getByText('50 % alderspensjon', { exact: false })
     ).toBeVisible()
     expect(screen.getByText('80 % uføretrygd', { exact: false })).toBeVisible()
+    expect(screen.getByTestId('stegvisning-start-alert')).toBeVisible()
   })
 
   it('rendrer slik den skal med vedtak om alderspensjon og AFP privat', async () => {
@@ -135,6 +137,7 @@ describe('stegvisning - Start', () => {
     expect(
       screen.getByText('AFP i privat sektor', { exact: false })
     ).toBeVisible()
+    expect(screen.getByTestId('stegvisning-start-alert')).toBeVisible()
   })
 
   it('rendrer slik den skal med vedtak om alderspensjon og AFP offentlig', async () => {
@@ -170,6 +173,7 @@ describe('stegvisning - Start', () => {
     expect(
       screen.getByText('AFP i offentlig sektor', { exact: false })
     ).toBeVisible()
+    expect(screen.getByTestId('stegvisning-start-alert')).toBeVisible()
   })
 
   it('rendrer slik den skal med fremtidig vedtak', async () => {
@@ -200,6 +204,7 @@ describe('stegvisning - Start', () => {
       'stegvisning.start.title Ola!'
     )
     expect(screen.getByText('stegvisning.start.button')).toBeVisible()
+    expect(screen.getByTestId('stegvisning-start-alert')).toBeVisible()
   })
 
   it('rendrer slik den skal med vedtak om alderspensjon og fremtidig vedtak', async () => {
@@ -240,6 +245,7 @@ describe('stegvisning - Start', () => {
     expect(
       screen.queryByText('stegvisning.start.button')
     ).not.toBeInTheDocument()
+    expect(screen.getByTestId('stegvisning-start-alert')).toBeVisible()
   })
 
   it('rendrer slik den skal med vedtak om pre2025 offentlig Afp', async () => {
@@ -266,6 +272,7 @@ describe('stegvisning - Start', () => {
     expect(
       screen.getByTestId('stegvisning-start-ingress-pre2025-offentlig-afp')
     ).toBeVisible()
+    expect(screen.getByTestId('stegvisning-start-alert')).toBeVisible()
   })
 
   it('kaller onNext når brukeren klikker på Neste', async () => {

--- a/src/pages/LandingPage/LandingPage.tsx
+++ b/src/pages/LandingPage/LandingPage.tsx
@@ -32,10 +32,6 @@ export const LandingPage = () => {
     })
   }, [])
 
-  const gaaTilDetaljertKalkulator = () => {
-    window.open(externalUrls.detaljertKalkulator, '_self')
-  }
-
   const gaaTilEnkelKalkulator = () => {
     navigate(paths.start)
   }
@@ -43,14 +39,6 @@ export const LandingPage = () => {
   const gaaTilUinnloggetKalkulator = () => {
     window.open(externalUrls.uinnloggetKalkulator, '_self')
   }
-
-  const detaljertKalkulatorButtonText = isLoggedIn
-    ? intl.formatMessage({
-        id: 'landingsside.button.detaljert_kalkulator',
-      })
-    : intl.formatMessage({
-        id: 'landingsside.button.detaljert_kalkulator_utlogget',
-      })
 
   const enkelKalkulatorButtonText = isLoggedIn
     ? intl.formatMessage({
@@ -146,28 +134,6 @@ export const LandingPage = () => {
               height="1.25rem"
             />
           </Link>
-
-          <div>
-            <BodyLong>
-              {intl.formatMessage({
-                id: 'landingsside.velge_mellom_detaljert_og_enkel_2',
-              })}
-            </BodyLong>
-          </div>
-
-          <div>
-            <HStack gap="4">
-              <Button
-                data-testid="landingside-detaljert-kalkulator-button"
-                variant="secondary"
-                onClick={wrapLogger(BUTTON_KLIKK, {
-                  tekst: 'Detaljert pensjonskalkulator',
-                })(gaaTilDetaljertKalkulator)}
-              >
-                {detaljertKalkulatorButtonText}
-              </Button>
-            </HStack>
-          </div>
         </VStack>
       </section>
     )

--- a/src/pages/LandingPage/__tests__/LandingPage.test.tsx
+++ b/src/pages/LandingPage/__tests__/LandingPage.test.tsx
@@ -108,33 +108,6 @@ describe('LandingPage', () => {
     })
   })
 
-  it('går til detaljert kalkulator når brukeren klikker på detaljert kalkulator knappen', async () => {
-    const user = userEvent.setup()
-
-    const open = vi.fn()
-    vi.stubGlobal('open', open)
-
-    const router = createMemoryRouter(routes, {
-      basename: BASE_PATH,
-      initialEntries: [`${BASE_PATH}${paths.login}`],
-    })
-    render(<RouterProvider router={router} />, {
-      hasRouter: false,
-    })
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId('landingside-detaljert-kalkulator-button')
-      ).toBeDefined()
-    })
-
-    await user.click(
-      screen.getByTestId('landingside-detaljert-kalkulator-button')
-    )
-
-    expect(open).toHaveBeenCalledWith(externalUrls.detaljertKalkulator, '_self')
-  })
-
   it('går til enkel kalkulator når brukeren klikker på enkel kalkulator knappen', async () => {
     mockErrorResponse('/oauth2/session', {
       baseUrl: `${HOST_BASEURL}`,

--- a/src/pages/LandingPage/__tests__/LandingPage.test.tsx
+++ b/src/pages/LandingPage/__tests__/LandingPage.test.tsx
@@ -57,14 +57,6 @@ describe('LandingPage', () => {
       expect(
         screen.getByText('landingsside.link.personopplysninger')
       ).toBeVisible()
-      expect(
-        screen.getByText('landingsside.velge_mellom_detaljert_og_enkel_2')
-      ).toBeVisible()
-      // Viser riktig tekst på Detaljert kalkulator knappen
-      expect(
-        screen.getByTestId('landingside-detaljert-kalkulator-button')
-          .textContent
-      ).toBe('landingsside.button.detaljert_kalkulator')
     })
   })
 
@@ -101,14 +93,6 @@ describe('LandingPage', () => {
       expect(
         screen.getByText('landingsside.link.personopplysninger')
       ).toBeVisible()
-      expect(
-        screen.getByText('landingsside.velge_mellom_detaljert_og_enkel_2')
-      ).toBeVisible()
-      // Viser riktig tekst på Detaljert kalkulator knappen
-      expect(
-        screen.getByTestId('landingside-detaljert-kalkulator-button')
-          .textContent
-      ).toBe('landingsside.button.detaljert_kalkulator_utlogget')
       // Viser info om Uinnlogget kalkulator
       expect(
         screen.getByText('landingsside.text.uinnlogget_kalkulator')

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -52,6 +52,7 @@ export const routes: RouteObject[] = [
         shouldShowLogo
         hasWhiteBg
         shouldRedirectNonAuthenticated={false}
+        noMinHeight={true}
       >
         <Outlet />
       </PageFramework>

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -58,7 +58,6 @@ export default {
     'You must use our detailed calculator. It provides an estimate of',
   'landingsside.velge_mellom_detaljert_og_enkel':
     'In the pension calculator, you can get an estimate of',
-  'landingsside.velge_mellom_detaljert_og_enkel_2': 'MANGLER_TEKST',
   'landingsside.button.detaljert_kalkulator_utlogget':
     'Log in to the detailed pension calculator',
   'landingsside.button.detaljert_kalkulator': 'Detailed Pension Calculator',
@@ -105,6 +104,8 @@ export default {
     'To get an estimate of your pension, you must answer all the following questions.',
   'stegvisning.start.button': 'Get Started',
   'stegvisning.start.link': 'Personal data used in the pension calculator',
+  'stegvisning.start.alert.title': 'MANGLER_TEKST',
+  'stegvisning.start.alert.description': 'MANGLER_TEKST',
   'stegvisning.start_brukere_fyllt_75.title': 'MANGLER_TEKST',
   'stegvisning.start_brukere_fyllt_75.ingress': 'MANGLER_TEKST',
   'stegvisning.start_brukere_fyllt_75.button': 'MANGLER_TEKST',

--- a/src/translations/nb.ts
+++ b/src/translations/nb.ts
@@ -61,8 +61,6 @@ const translations = {
     'Du må bruke vår detaljerte kalkulator. Den gir deg et estimat på',
   'landingsside.velge_mellom_detaljert_og_enkel':
     'I pensjonskalkulatoren kan du få et estimat på ',
-  'landingsside.velge_mellom_detaljert_og_enkel_2':
-    'Hvis du er født før 1963 og har offentlig tjenestepensjon fra Statens pensjonskasse, kan du foreløpig kun se denne i detaljert pensjonskalkulator.',
   'landingsside.button.detaljert_kalkulator_utlogget':
     'Logg inn i detaljert pensjonskalkulator',
   'landingsside.button.detaljert_kalkulator': 'Detaljert pensjonskalkulator',
@@ -115,6 +113,9 @@ const translations = {
   'stegvisning.start.button': 'Kom i gang',
   'stegvisning.start.link':
     'Personopplysninger som brukes i pensjonskalkulator',
+  'stegvisning.start.alert.title': 'Kjenner du deg ikke helt igjen?',
+  'stegvisning.start.alert.description':
+    'Vi har laget ny kalkulator og pensjonert den gamle.',
   'stegvisning.start_brukere_fyllt_75.title':
     'Du kan dessverre ikke beregne alderspensjon i kalkulatoren etter at du har fylt 75 år',
   'stegvisning.start_brukere_fyllt_75.ingress':

--- a/src/translations/nn.ts
+++ b/src/translations/nn.ts
@@ -51,7 +51,6 @@ export default {
     'Du må bruke vår detaljerte kalkulator. Der får du rekna ut alderspensjonen frå folketrygda (Nav), avtalefesta pensjon (AFP) og pensjonsavtalar (arbeidsgjevarar og sparing)',
   'landingsside.velge_mellom_detaljert_og_enkel':
     'Du kan velgje mellom enkel eller detaljert kalkulator. Enkel kalkulator passar for deg som vil ha eit rask oversyn. Detaljert pensjonskalkulator passar for deg som vil ha ei meir spesifisert utrekning.',
-  'landingsside.velge_mellom_detaljert_og_enkel_2': 'MANGLER_TEKST',
   'landingsside.button.detaljert_kalkulator_utlogget':
     'Logg inn i detaljert pensjonskalkulator',
   'landingsside.button.detaljert_kalkulator': 'Detaljert pensjonskalkulator',
@@ -90,6 +89,8 @@ export default {
   'stegvisning.start.button': 'Kom i gang',
   'stegvisning.start.link':
     'Personopplysningar som vert brukt i enkel kalkulator',
+  'stegvisning.start.alert.title': 'MANGLER_TEKST',
+  'stegvisning.start.alert.description': 'MANGLER_TEKST',
   'stegvisning.start_brukere_fyllt_75.title': 'MANGLER_TEKST',
   'stegvisning.start_brukere_fyllt_75.ingress': 'MANGLER_TEKST',
   'stegvisning.start_brukere_fyllt_75.button': 'MANGLER_TEKST',


### PR DESCRIPTION
[PEK-1444](https://jira.adeo.no/projects/PEK/issues/PEK-1444)

- Hele avsnittet om TP fra SPK på landing side fjernet
- Knapp til gammel kalkulator ("Detaljert pensjonskalkulator") fjernet
- Lagt til midlertidig varsel på /start for brukere med/uten vedtak, født før/etter 1963

### Before
<img width="694" height="506" alt="Screenshot 2025-08-28 at 16 14 31" src="https://github.com/user-attachments/assets/7b837ea3-973c-4798-9dca-bcc99639cca6" />

<img width="668" height="450" alt="Screenshot 2025-08-28 at 16 13 55" src="https://github.com/user-attachments/assets/495e05a4-5875-483d-b603-970a715fddae" />

### Etter
<img width="471" height="382" alt="Screenshot 2025-08-28 at 16 08 02" src="https://github.com/user-attachments/assets/0f857d88-c64b-41d5-97b4-c43a46ce0aeb" />
<img width="676" height="678" alt="Screenshot 2025-08-28 at 16 08 32" src="https://github.com/user-attachments/assets/a437dd3c-b04a-4a4d-b32d-f271a9e02db5" />
<img width="685" height="591" alt="Screenshot 2025-08-28 at 16 09 24" src="https://github.com/user-attachments/assets/4782aa50-ad62-4022-ab7b-09a66a83be73" />
