### PR TITLE
Fikser bug med info eventer som var ikke logged in amplitude

### DIFF
--- a/src/router/loaders.tsx
+++ b/src/router/loaders.tsx
@@ -97,9 +97,6 @@ export const stepStartAccessGuard = async () => {
     apiSlice.endpoints.getErApoteker.initiate()
   )
 
-  const state = store.getState()
-  const isLoggedIn = selectIsLoggedIn(state)
-
   const [
     vedlikeholdsmodusFeatureToggle,
     getLoependeVedtakRes,
@@ -115,6 +112,9 @@ export const stepStartAccessGuard = async () => {
   if (vedlikeholdsmodusFeatureToggle.data?.enabled) {
     return redirect(paths.kalkulatorVirkerIkke)
   }
+
+  const state = store.getState()
+  const isLoggedIn = selectIsLoggedIn(state)
 
   if (isLoggedIn) {
     if (!getPersonRes.isSuccess) {


### PR DESCRIPTION
**Problem:**

Som en del av denne [saken](https://jira.adeo.no/browse/PEK-1230) ble logging av events tidligere wrappet rundt en isLoggedIn-sjekk. Problemet var at isLoggedIn-state ikke var oppdatert på tidspunktet den ble hentet, og returnerte derfor alltid false. Dermed ble info-eventene aldri sendt til Amplitude, selv om state senere ble oppdatert.

**Løsning**

Fiksen innebærer å flytte henting av state til et senere tidspunkt, slik at isLoggedIn er korrekt oppdatert før events logges.