### PR TITLE
PEK-618: Legg til endepunkt for /status og /feature/:toggle som ikke trenger autentisering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ coverage
 .stylelintcache
 cypress/videos
 cypress/screenshots
+overrides.env
 analice.html
 vite.config.ts.*
 .sanity

--- a/server/server.ts
+++ b/server/server.ts
@@ -116,6 +116,43 @@ app.get('/internal/health/readiness', (_req: Request, res: Response) => {
   res.sendStatus(200)
 })
 
+// Status probes from backend, trenger ikke autentisering
+app.get(
+  '/pensjon/kalkulator/api/status',
+  async (req: Request, res: Response) => {
+    try {
+      const res_status = await fetch(
+        `${PENSJONSKALKULATOR_BACKEND}/api/status`,
+        {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            'x_correlation-id': req.headers['x_correlation-id'] as string,
+          },
+        }
+      )
+
+      const status_data = await res_status.json()
+      res.send(status_data)
+    } catch (error) {
+      console.error('Error fetching status:', error)
+      res.status(500).send({ error: 'Internal Server Error' })
+    }
+  }
+)
+
+// Unntak for feature toggle, trenger ikke autentisering
+app.get(
+  '/pensjon/kalkulator/api/feature/:toggle',
+  async (req: Request, res: Response) => {
+    const toggle = req.params.toggle
+
+    res.send({
+      enabled: unleash.isEnabled(toggle),
+    })
+  }
+)
+
 app.use((req, res, next) => {
   const start = Date.now()
   res.on('finish', () => {


### PR DESCRIPTION
[PEK-618](https://jira.adeo.no/projects/PEK/issues/PEK-618)
Implementerer to nye API-endepunkt som ikke krever autentisering:
- `/pensjon/kalkulator/api/status` for helsesjekk av backend-tjenesten
- `/pensjon/kalkulator/api/feature/:toggle` for tilgang til feature toggles
-  Bruk unleash fra BFF i stedet for å gå mot backend

Lager en ny PR for denne [PR](https://github.com/navikt/pensjonskalkulator-frontend/pull/2054) som var veldig uttadert