### PR TITLE
PEK-1426 fix back navigasjon from login page

### DIFF
--- a/src/pages/LandingPage/LandingPage.tsx
+++ b/src/pages/LandingPage/LandingPage.tsx
@@ -13,6 +13,7 @@ import {
   VStack,
 } from '@navikt/ds-react'
 
+import { HOST_BASEURL } from '@/paths'
 import { externalUrls, paths } from '@/router/constants'
 import { useAppSelector } from '@/state/hooks'
 import { selectIsLoggedIn } from '@/state/session/selectors'
@@ -33,7 +34,14 @@ export const LandingPage = () => {
   }, [])
 
   const gaaTilEnkelKalkulator = () => {
-    navigate(paths.start)
+    if (isLoggedIn) {
+      navigate(paths.start)
+    } else {
+      window.open(
+        `${HOST_BASEURL}/oauth2/login?redirect=${encodeURIComponent(window.location.pathname)}`,
+        '_self'
+      )
+    }
   }
 
   const gaaTilUinnloggetKalkulator = () => {

--- a/src/pages/LandingPage/LandingPage.tsx
+++ b/src/pages/LandingPage/LandingPage.tsx
@@ -38,7 +38,7 @@ export const LandingPage = () => {
       navigate(paths.start)
     } else {
       window.open(
-        `${HOST_BASEURL}/oauth2/login?redirect=${encodeURIComponent(window.location.pathname)}`,
+        `${HOST_BASEURL}/oauth2/login?redirect=${encodeURIComponent(`${HOST_BASEURL}${paths.start}`)}`,
         '_self'
       )
     }

--- a/src/pages/LandingPage/__tests__/LandingPage.test.tsx
+++ b/src/pages/LandingPage/__tests__/LandingPage.test.tsx
@@ -135,7 +135,7 @@ describe('LandingPage', () => {
       )
     })
 
-    expect(navigateMock).toHaveBeenCalledWith(`${paths.start}`)
+    expect(navigateMock).not.toHaveBeenCalledWith(`${paths.start}`)
   })
 
   it('går til uinnlogget kalkulator når brukeren klikker på uinnlogget kalkulator knappen', async () => {


### PR DESCRIPTION
[PEK-1426](https://jira.adeo.no/projects/PEK/issues/PEK-1426)

## Before

Navigating back from [ID-porten](https://login.test.idporten.no/authorize/selector ) loads the start page with only the header and footer visible

https://github.com/user-attachments/assets/c95d4ff0-2150-4386-b7e2-6a7e1969bf6e

## After

Navigating back from [ID-porten](https://login.test.idporten.no/authorize/selector ) loads the login page with correct content


https://github.com/user-attachments/assets/16961e87-8d92-4ac2-abee-2ff815f95342


