### PR TITLE
Bugfix: Move getState after api calls are complete

### DIFF
--- a/src/router/loaders.tsx
+++ b/src/router/loaders.tsx
@@ -97,9 +97,6 @@ export const stepStartAccessGuard = async () => {
     apiSlice.endpoints.getErApoteker.initiate()
   )
 
-  const state = store.getState()
-  const isLoggedIn = selectIsLoggedIn(state)
-
   const [vedlikeholdsmodusFeatureToggle, getLoependeVedtakRes, getPersonRes] =
     await Promise.all([
       vedlikeholdsmodusFeatureToggleQuery,
@@ -116,6 +113,11 @@ export const stepStartAccessGuard = async () => {
   if (vedlikeholdsmodusFeatureToggle.data?.enabled) {
     return redirect(paths.kalkulatorVirkerIkke)
   }
+
+  // Hent state etter at alle kall er fullført
+  // Dette sikrer at vi har den mest oppdaterte tilstanden og dermed logger riktig informasjon til Umami
+  const state = store.getState()
+  const isLoggedIn = selectIsLoggedIn(state)
 
   if (isLoggedIn) {
     if (!getPersonRes.isSuccess) {


### PR DESCRIPTION
As part of this [PR](https://github.com/navikt/pensjonskalkulator-frontend/pull/2358/files#diff-00f47df6f7312d676f6c90b6182d06fdc364368008979f6664743a955fddd79bR100-R114) `getState` was moved before the api calls which leads to a problem where we do not log correct data to Umami/Amplitude.
In this PR, it is moved back to where it is supposed to be