### PR TITLE
Justere tekst om PGI på beregningssiden for brukere med uføretrygd

### DIFF
--- a/src/translations/nb.ts
+++ b/src/translations/nb.ts
@@ -430,7 +430,7 @@ const translations = {
   'beregning.avansert.rediger.inntekt_frem_til_endring.label':
     'Pensjonsgivende årsinntekt frem til endring',
   'beregning.avansert.rediger.inntekt_frem_til_uttak.description_ufoere':
-    'Uten uføretrygd og uførepensjon.',
+    'Uføretrygd og uførepensjon skal ikke være med.',
   'beregning.avansert.rediger.inntekt_frem_til_uttak.description':
     'kr per år før skatt',
   'beregning.avansert.rediger.pre2025_offentlig_afp.alert':
@@ -716,7 +716,7 @@ const translations = {
   'inntekt.endre_inntekt_modal.textfield.description':
     'Dagens kroneverdi før skatt',
   'inntekt.endre_inntekt_modal.textfield.description.ufoere':
-    'Ikke uføretrygd og uførepensjon. Dagens kroneverdi før skatt',
+    'Uføretrygd og uførepensjon skal ikke være med. Dagens kroneverdi før skatt',
   'inntekt.endre_inntekt_modal.paragraph':
     'Når du oppdaterer inntekten, må du velge alder på nytt.',
   'inntekt.endre_inntekt_modal.textfield.validation_error.required':

--- a/src/translations/nb.ts
+++ b/src/translations/nb.ts
@@ -716,7 +716,7 @@ const translations = {
   'inntekt.endre_inntekt_modal.textfield.description':
     'Dagens kroneverdi før skatt',
   'inntekt.endre_inntekt_modal.textfield.description.ufoere':
-    'Uføretrygd og uførepensjon skal ikke være med. Dagens kroneverdi før skatt',
+    'Uføretrygd og uførepensjon skal ikke være med. Dagens kroneverdi før skatt.',
   'inntekt.endre_inntekt_modal.paragraph':
     'Når du oppdaterer inntekten, må du velge alder på nytt.',
   'inntekt.endre_inntekt_modal.textfield.validation_error.required':


### PR DESCRIPTION
[PEK-1353](https://jira.adeo.no/browse/PEK-1353)


i modal som vises i Enkel og Avansert beregning:

> Før:
> <img width="468" height="370" alt="Screenshot 2025-10-06 at 10 50 53" src="https://github.com/user-attachments/assets/eddf597b-f51a-44a6-a2fc-ab7d9374eb7b" />
> 
> Etter:
> <img width="468" height="370" alt="Screenshot 2025-10-06 at 11 00 27" src="https://github.com/user-attachments/assets/6edc7e08-fe10-4d71-9e72-3a5f79324fec" />
> 

i Avansert skjema (øverst):

> Før:
> <img width="468" height="209" alt="Screenshot 2025-10-06 at 11 03 44" src="https://github.com/user-attachments/assets/bc903a24-1339-4b44-aac7-170b105f29cc" />
> 
> Etter:
> <img width="468" height="209" alt="Screenshot 2025-10-06 at 11 07 53" src="https://github.com/user-attachments/assets/77611ea6-db03-4848-8a0b-a6c4fcb46135" />
> 