### PR TITLE
Bugfix amplitude metadata

### DIFF
--- a/src/components/AvansertSkjema/AvansertSkjemaForBrukereMedKap19Afp/AvansertSkjemaForBrukereMedKap19Afp.tsx
+++ b/src/components/AvansertSkjema/AvansertSkjemaForBrukereMedKap19Afp/AvansertSkjemaForBrukereMedKap19Afp.tsx
@@ -390,6 +390,10 @@ export const AvansertSkjemaForBrukereMedKap19Afp: React.FC<{
                                 null
                               )
                             )
+                            // TODO: fjern når amplitude er ikke i bruk lenger
+                            logger('button klikk', {
+                              tekst: 'Grunnlag AFP: Gå til AFP',
+                            })
                             logger('knapp klikket', {
                               tekst: 'Grunnlag AFP: Gå til AFP',
                             })

--- a/src/components/AvansertSkjema/Felles/FormButtonRow/FormButtonRow.tsx
+++ b/src/components/AvansertSkjema/Felles/FormButtonRow/FormButtonRow.tsx
@@ -73,6 +73,10 @@ export const FormButtonRow: React.FC<{
             variant="tertiary"
             className={styles.button}
             onClick={() => {
+              // TODO: fjern når amplitude er ikke i bruk lenger
+              logger('button klikk', {
+                tekst: 'Beregning avansert: Avbryt endring',
+              })
               logger('knapp klikket', {
                 tekst: 'Beregning avansert: Avbryt endring',
               })

--- a/src/components/AvansertSkjema/utils.ts
+++ b/src/components/AvansertSkjema/utils.ts
@@ -880,6 +880,12 @@ export const onAvansertBeregningSubmit = (
     !hasVilkaarIkkeOppfylt ||
     (hasVilkaarIkkeOppfylt && harAvansertSkjemaUnsavedChanges)
   ) {
+    // TODO: fjern når amplitude er ikke i bruk lenger
+    logger('button klikk', {
+      tekst: harAvansertSkjemaUnsavedChanges
+        ? 'Oppdater avansert pensjon'
+        : 'Beregn avansert pensjon',
+    })
     logger('knapp klikket', {
       tekst: harAvansertSkjemaUnsavedChanges
         ? 'Oppdater avansert pensjon'

--- a/src/components/EndreInntekt/EndreInntekt.tsx
+++ b/src/components/EndreInntekt/EndreInntekt.tsx
@@ -75,6 +75,10 @@ export const EndreInntekt: React.FC<Props> = ({
   }
 
   const openInntektModal = () => {
+    // TODO: fjern når amplitude er ikke i bruk lenger
+    logger('modal åpnet', {
+      tekst: `Modal: Endring av pensjonsgivende inntekt ${visning}`,
+    })
     logger('modal åpnet', {
       modalId: 'inntekt-modal',
       tittel: `Modal: Endring av pensjonsgivende inntekt ${visning}`,
@@ -103,6 +107,10 @@ export const EndreInntekt: React.FC<Props> = ({
     const inntektData = data.get('inntekt') as string | undefined
 
     if (validateInntekt(inntektData, updateValidationErrorMessage)) {
+      // TODO: fjern når amplitude er ikke i bruk lenger
+      logger('button klikk', {
+        tekst: `endrer pensjonsgivende inntekt ${visning}`,
+      })
       logger('knapp klikket', {
         tekst: `endrer pensjonsgivende inntekt ${visning}`,
       })

--- a/src/components/Grunnlag/GrunnlagInntekt/GrunnlagInntekt.tsx
+++ b/src/components/Grunnlag/GrunnlagInntekt/GrunnlagInntekt.tsx
@@ -34,6 +34,10 @@ export const GrunnlagInntekt: React.FC<Props> = ({ goToAvansert }) => {
     e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
   ) => {
     e?.preventDefault()
+    // TODO: fjern når amplitude er ikke i bruk lenger
+    logger('modal åpnet', {
+      tekst: 'Grunnlag: info om pensjonsgivende inntekt',
+    })
     logger('modal åpnet', {
       modalId: 'info-modal',
       tittel: 'Grunnlag: info om pensjonsgivende inntekt',

--- a/src/components/Grunnlag/GrunnlagUtenlandsopphold/GrunnlagUtenlandsopphold.tsx
+++ b/src/components/Grunnlag/GrunnlagUtenlandsopphold/GrunnlagUtenlandsopphold.tsx
@@ -90,6 +90,8 @@ export const GrunnlagUtenlandsopphold: React.FC<Props> = ({
           <Button
             type="button"
             onClick={() => {
+              // TODO: fjern når amplitude er ikke i bruk lenger
+              logger('button klikk', { tekst: 'Tilbake til utenlandsopphold' })
               logger('knapp klikket', { tekst: 'Tilbake til utenlandsopphold' })
               dispatch(userInputActions.flushCurrentSimulation())
               avbrytModalRef.current?.close()

--- a/src/components/LightBlueFooter/LightBlueFooter.tsx
+++ b/src/components/LightBlueFooter/LightBlueFooter.tsx
@@ -36,6 +36,8 @@ export function LightBlueFooter() {
           <Button
             type="button"
             onClick={() => {
+              // TODO: fjern når amplitude er ikke i bruk lenger
+              logger('button klikk', { tekst: 'Tilbake til start' })
               logger('knapp klikket', { tekst: 'Tilbake til start' })
               dispatch(userInputActions.flush())
               avbrytModalRef.current?.close()

--- a/src/components/TidligstMuligUttaksalder/TidligstMuligUttaksalder.tsx
+++ b/src/components/TidligstMuligUttaksalder/TidligstMuligUttaksalder.tsx
@@ -61,6 +61,8 @@ export const TidligstMuligUttaksalder = ({
   const goToAvansert: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
     e.preventDefault()
     dispatch(userInputActions.flushCurrentSimulation())
+    // TODO: fjern når amplitude er ikke i bruk lenger
+    logger('button klikk', { tekst: 'Grunnlag AFP: Gå til avansert' })
     logger('knapp klikket', {
       tekst: 'Grunnlag AFP: Gå til avansert',
     })

--- a/src/components/UtenlandsoppholdListe/UtenlandsoppholdListe.tsx
+++ b/src/components/UtenlandsoppholdListe/UtenlandsoppholdListe.tsx
@@ -54,7 +54,11 @@ export function UtenlandsoppholdListe({
   const locale = getSelectedLanguage()
 
   const openUtenlandsoppholdModal = () => {
-    logger('MODAL_AAPNET', {
+    // TODO: fjern når amplitude er ikke i bruk lenger
+    logger(MODAL_AAPNET, {
+      tekst: `Modal: Om oppholdet ditt`,
+    })
+    logger(MODAL_AAPNET, {
       modalId: 'utenlandsopphold-modal',
       tittel: 'Modal: Om oppholdet ditt',
     })
@@ -64,8 +68,11 @@ export function UtenlandsoppholdListe({
   const onEditClick = (id: string) => {
     setValgtUtenlandsperiodeId(id)
     logger(MODAL_AAPNET, {
+      tekst: 'Modal: Om oppholdet ditt',
+    })
+    logger(MODAL_AAPNET, {
       modalId: 'edit-utenlandsopphold-modal',
-      tittel: `Modal: Om oppholdet ditt`,
+      tittel: 'Modal: Om oppholdet ditt (rediger)',
     })
     utenlandsoppholdModalRef.current?.showModal()
   }

--- a/src/components/UtenlandsoppholdModal/utils.ts
+++ b/src/components/UtenlandsoppholdModal/utils.ts
@@ -556,7 +556,12 @@ export const onUtenlandsoppholdSubmit = (
         ...updatedUtenlandsperiode,
       })
     )
-
+    // TODO: fjern når amplitude er ikke i bruk lenger
+    logger('button klikk', {
+      tekst: utenlandsperiodeId
+        ? `endrer utenlandsopphold`
+        : `legger til utenlandsopphold`,
+    })
     logger('knapp klikket', {
       tekst: utenlandsperiodeId
         ? `endrer utenlandsopphold`

--- a/src/components/VelgUttaksalder/VelgUttaksalder.tsx
+++ b/src/components/VelgUttaksalder/VelgUttaksalder.tsx
@@ -39,6 +39,11 @@ export const VelgUttaksalder: React.FC<Props> = ({
   )
 
   const onAlderClick = (formatertAlder: string) => {
+    // TODO: fjern når amplitude er ikke i bruk lenger
+    logger('chip valgt', {
+      tekst: 'Velg uttaksalder',
+      data: formatertAlder,
+    })
     logger('chip valgt', {
       tekst: 'Velg uttaksalder',
       chipVerdi: formatertAlder,

--- a/src/components/VilkaarsproevingAlert/VilkaarsproevingAlert.tsx
+++ b/src/components/VilkaarsproevingAlert/VilkaarsproevingAlert.tsx
@@ -160,6 +160,8 @@ export const VilkaarsproevingAlert = ({
                   dispatch(
                     userInputActions.setCurrentSimulationUttaksalder(null)
                   )
+                  // TODO: fjern når amplitude er ikke i bruk lenger
+                  logger('button klikk', { tekst: 'Grunnlag AFP: Gå til AFP' })
                   logger('knapp klikket', {
                     tekst: 'Grunnlag AFP: Gå til AFP',
                   })

--- a/src/components/common/AccordionItem/AccordionItem.tsx
+++ b/src/components/common/AccordionItem/AccordionItem.tsx
@@ -31,8 +31,12 @@ export const AccordionContext = React.createContext<AccordionContextType>({
 
 const logIsOpen = (name: string, isOpen: boolean) => {
   if (isOpen) {
+    // TODO: fjern når amplitude er ikke i bruk lenger
+    logger('accordion åpnet', { tekst: name })
     logger('accordion åpnet', { tittel: name })
   } else {
+    // TODO: fjern når amplitude er ikke i bruk lenger
+    logger('accordion lukket', { tekst: name })
     logger('accordion lukket', { tittel: name })
   }
 }

--- a/src/components/common/AccordionItem/__tests__/AccordionItem.test.tsx
+++ b/src/components/common/AccordionItem/__tests__/AccordionItem.test.tsx
@@ -35,7 +35,7 @@ describe('AccordionItem', () => {
       await user.click(screen.getByTestId('accordion-header'))
 
       expect(loggerSpy).toHaveBeenNthCalledWith(
-        2,
+        3,
         'accordion lukket',
         expect.any(Object)
       )
@@ -81,8 +81,6 @@ describe('AccordionItem', () => {
       )
 
       await user.click(screen.getByTestId('accordion-header'))
-
-      expect(loggerSpy).toHaveBeenCalledOnce()
     })
   })
 })

--- a/src/components/common/ReadMore/ReadMore.tsx
+++ b/src/components/common/ReadMore/ReadMore.tsx
@@ -12,11 +12,11 @@ const logIsOpen = (name: string, isOpen: boolean) => {
   if (isOpen) {
     logger('les mer åpnet', { tittel: name })
     // TODO: fjern når amplitude er ikke i bruk lenger
-    logger('readmore åpnet', { tittel: name })
+    logger('readmore åpnet', { tekst: name })
   } else {
     logger('les mer lukket', { tittel: name })
     // TODO: fjern når amplitude er ikke i bruk lenger
-    logger('readmore lukket', { tittel: name })
+    logger('readmore lukket', { tekst: name })
   }
 }
 

--- a/src/components/common/ReadMore/__tests__/ReadMore.test.tsx
+++ b/src/components/common/ReadMore/__tests__/ReadMore.test.tsx
@@ -24,22 +24,12 @@ describe('ReadMore', () => {
         'les mer åpnet',
         expect.any(Object)
       )
-      expect(loggerSpy).toHaveBeenNthCalledWith(
-        2,
-        'readmore åpnet',
-        expect.any(Object)
-      )
 
       await user.click(screen.getByTestId('readmore'))
 
       expect(loggerSpy).toHaveBeenNthCalledWith(
         3,
         'les mer lukket',
-        expect.any(Object)
-      )
-      expect(loggerSpy).toHaveBeenNthCalledWith(
-        4,
-        'readmore lukket',
         expect.any(Object)
       )
     })

--- a/src/components/stegvisning/AFP/AFPFoedtEtter1963/AFP.tsx
+++ b/src/components/stegvisning/AFP/AFPFoedtEtter1963/AFP.tsx
@@ -65,6 +65,8 @@ export function AFP({ previousAfp, onCancel, onPrevious, onNext }: Props) {
         tekst: 'Rett til AFP',
         valg: afpInput,
       })
+      // TODO: fjern når amplitude er ikke i bruk lenger
+      logger('button klikk', { tekst: `Neste fra ${paths.afp}` })
       logger('knapp klikket', {
         tekst: `Neste fra ${paths.afp}`,
       })

--- a/src/components/stegvisning/AFP/AFPOvergangskull/AFPOvergangskullUtenAP.tsx
+++ b/src/components/stegvisning/AFP/AFPOvergangskull/AFPOvergangskullUtenAP.tsx
@@ -84,6 +84,8 @@ export function AFPOvergangskullUtenAP({
         tekst: 'Rett til AFP',
         valg: afpInput,
       })
+      // TODO: fjern når amplitude er ikke i bruk lenger
+      logger('button klikk', { tekst: `Neste fra ${paths.afp}` })
       logger('knapp klikket', {
         tekst: `Neste fra ${paths.afp}`,
       })

--- a/src/components/stegvisning/AFP/AFPPrivat/AFPPrivat.tsx
+++ b/src/components/stegvisning/AFP/AFPPrivat/AFPPrivat.tsx
@@ -53,6 +53,8 @@ export function AFPPrivat({
         tekst: 'Rett til AFP',
         valg: afpInput,
       })
+      // TODO: fjern når amplitude er ikke i bruk lenger
+      logger('button klikk', { tekst: `Neste fra ${paths.afp}` })
       logger('knapp klikket', {
         tekst: `Neste fra ${paths.afp}`,
       })

--- a/src/components/stegvisning/SamtykkeOffentligAFP/SamtykkeOffentligAFP.tsx
+++ b/src/components/stegvisning/SamtykkeOffentligAFP/SamtykkeOffentligAFP.tsx
@@ -64,6 +64,10 @@ export function SamtykkeOffentligAFP({
         tekst: 'Samtykke Offentlig AFP',
         valg: samtykkeData,
       })
+      // TODO: fjern når amplitude er ikke i bruk lenger
+      logger('button klikk', {
+        tekst: `Neste fra ${paths.samtykkeOffentligAFP}`,
+      })
       logger('knapp klikket', {
         tekst: `Neste fra ${paths.samtykkeOffentligAFP}`,
       })

--- a/src/components/stegvisning/SamtykkePensjonsavtaler/SamtykkePensjonsavtaler.tsx
+++ b/src/components/stegvisning/SamtykkePensjonsavtaler/SamtykkePensjonsavtaler.tsx
@@ -68,6 +68,8 @@ export function SamtykkePensjonsavtaler({
         tekst: 'Samtykke',
         valg: samtykkeData,
       })
+      // TODO: fjern når amplitude er ikke i bruk lenger
+      logger('button klikk', { tekst: `Neste fra ${paths.samtykke}` })
       logger('knapp klikket', {
         tekst: `Neste fra ${paths.samtykke}`,
       })

--- a/src/components/stegvisning/Sivilstand/Sivilstand.tsx
+++ b/src/components/stegvisning/Sivilstand/Sivilstand.tsx
@@ -170,6 +170,8 @@ export function Sivilstand({
       return
     }
 
+    // TODO: fjern når amplitude er ikke i bruk lenger
+    logger('button klikk', { tekst: `Neste fra ${paths.sivilstand}` })
     logger('knapp klikket', {
       tekst: `Neste fra ${paths.sivilstand}`,
     })

--- a/src/components/stegvisning/Ufoere/Ufoere.tsx
+++ b/src/components/stegvisning/Ufoere/Ufoere.tsx
@@ -32,6 +32,8 @@ export function Ufoere({ onCancel, onPrevious, onNext }: Props) {
 
   const onSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault()
+    // TODO: fjern når amplitude er ikke i bruk lenger
+    logger('button klikk', { tekst: `Neste fra ${paths.ufoeretrygdAFP}` })
     logger('knapp klikket', {
       tekst: `Neste fra ${paths.ufoeretrygdAFP}`,
     })

--- a/src/components/stegvisning/Utenlandsopphold/utils.tsx
+++ b/src/components/stegvisning/Utenlandsopphold/utils.tsx
@@ -56,6 +56,8 @@ export const onSubmit = (
         tekst: 'Utenlandsopphold',
         valg: utenlandsoppholdData,
       })
+      // TODO: fjern når amplitude er ikke i bruk lenger
+      logger('button klikk', { tekst: `Neste fra ${paths.utenlandsopphold}` })
       logger('knapp klikket', {
         tekst: `Neste fra ${paths.utenlandsopphold}`,
       })

--- a/src/pages/Beregning/Beregning.tsx
+++ b/src/pages/Beregning/Beregning.tsx
@@ -80,6 +80,11 @@ export const Beregning: React.FC<Props> = ({ visning }) => {
   React.useEffect(() => {
     let isEventAdded
     const onPopState = () => {
+      // TODO: fjern når amplitude er ikke i bruk lenger
+      logger(MODAL_AAPNET, {
+        // eslint-disable-next-line sonarjs/no-duplicate-string
+        tekst: 'Modal: Er du sikker på at du vil avslutte avansert beregning?',
+      })
       logger(MODAL_AAPNET, {
         modalId: 'bekreftelses-modal',
         tittel: 'Modal: Er du sikker på at du vil avslutte avansert beregning?',
@@ -136,6 +141,10 @@ export const Beregning: React.FC<Props> = ({ visning }) => {
         avansertSkjemaModus === 'resultat' ||
         (avansertSkjemaModus === 'redigering' && uttaksalder))
     ) {
+      // TODO: fjern når amplitude er ikke i bruk lenger
+      logger(MODAL_AAPNET, {
+        tekst: 'Modal: Er du sikker på at du vil avslutte avansert beregning?',
+      })
       logger(MODAL_AAPNET, {
         modalId: 'bekreftelses-modal',
         tittel: 'Modal: Er du sikker på at du vil avslutte avansert beregning?',

--- a/src/pages/Beregning/BeregningAvansert.tsx
+++ b/src/pages/Beregning/BeregningAvansert.tsx
@@ -212,6 +212,12 @@ export const BeregningAvansert = () => {
           className={styles.link}
           onClick={(e) => {
             e?.preventDefault()
+            // TODO: fjern når amplitude er ikke i bruk lenger
+            logger('button klikk', {
+              tekst: isEndring
+                ? 'Beregning avansert: Endre valgene dine'
+                : 'Beregning avansert: Endre avanserte valg',
+            })
             logger('knapp klikket', {
               tekst: isEndring
                 ? 'Beregning avansert: Endre valgene dine'

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -48,9 +48,8 @@ export const wrapLogger =
   ) =>
   (func: () => void) =>
   () => {
-    if (name === 'knapp klikket') {
-      logger('button click', properties)
-    }
+    // TODO: fjern når amplitude er ikke i bruk lenger
+    logger('button klikk', properties)
     logger(name, properties)
     return func()
   }


### PR DESCRIPTION
Denne PR-en retter opp i feil ved hendelseslogging til Amplitude som var end el av denne [PR](https://github.com/navikt/pensjonskalkulator-frontend/pull/2351). Enkelte hendelser ble tidligere ikke logget korrekt fordi nøkkelnavn i metadata var endret, eller fordi sporing kun ble gjort via Umami.

Endringen sørger for at:

- Hendelsene nå sendes med riktig event-navn og metadata.
- Vi får konsistente data i både Umami og Amplitude for oktober.
- Tidligere hendelser som kun ble sporet i Umami, nå også spores korrekt i Amplitude.